### PR TITLE
Bug fixed where you return to the connect to metamask screen after finishing the battle.

### DIFF
--- a/Assets/TanksMultiplayer/Prefabs/Network.prefab
+++ b/Assets/TanksMultiplayer/Prefabs/Network.prefab
@@ -44,8 +44,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c1ae42049abe4a298c88f40dc37bb5d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  offlineSceneIndex: 0
-  onlineSceneIndex: 1
+  offlineSceneIndex: 1
+  onlineSceneIndex: 2
   maxPlayers: 12
   playerPrefabs:
   - {fileID: 112386, guid: f30ad63695c27504b8c2aa87564a6ccc, type: 3}


### PR DESCRIPTION
The code of the Tanks game was loading the build index 0 when a player disconnects from a photon room.