### PR TITLE
Dummy customization

### DIFF
--- a/Assets/Prefabs/UI/DummyPartUIBlock.prefab
+++ b/Assets/Prefabs/UI/DummyPartUIBlock.prefab
@@ -1,0 +1,346 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5816341175208613868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5816341175208613869}
+  - component: {fileID: 5816341175208613859}
+  - component: {fileID: 5816341175208613858}
+  - component: {fileID: 4571636996137375491}
+  m_Layer: 5
+  m_Name: Item icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5816341175208613869
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175208613868}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 5816341177092805439}
+  m_Father: {fileID: 5816341175728514232}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 87.9693, y: -87.96936}
+  m_SizeDelta: {x: 175.9388, y: 175.9388}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5816341175208613859
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175208613868}
+  m_CullTransparentMesh: 0
+--- !u!114 &5816341175208613858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175208613868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: fea3eb6b159cafd4cbeec7532e97c92a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4571636996137375491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175208613868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5816341175208613858}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &5816341175723444726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5816341175723444727}
+  - component: {fileID: 5816341175723444725}
+  - component: {fileID: 5816341175723444724}
+  m_Layer: 5
+  m_Name: ON
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5816341175723444727
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175723444726}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5816341177092805439}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 26.9243, y: 26.9243}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5816341175723444725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175723444726}
+  m_CullTransparentMesh: 0
+--- !u!114 &5816341175723444724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175723444726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.4764151, b: 0.4764151, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0c9913652d6c1c54887c6cab3021a386, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5816341175728514235
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5816341175728514232}
+  - component: {fileID: 632899140686137899}
+  m_Layer: 5
+  m_Name: DummyPartUIBlock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5816341175728514232
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175728514235}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5816341175208613869}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 65, y: -65}
+  m_SizeDelta: {x: 130, y: 130}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &632899140686137899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341175728514235}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c101a7f96084784e9037a94fcc135fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_iconSprite: {fileID: 5816341175208613858}
+  m_selectedPinImage: {fileID: 5816341177092805436}
+  m_button: {fileID: 4571636996137375491}
+  m_partDesc: {fileID: 0}
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5816341177092805438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5816341177092805439}
+  - component: {fileID: 5816341177092805437}
+  - component: {fileID: 5816341177092805436}
+  m_Layer: 5
+  m_Name: Select
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5816341177092805439
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341177092805438}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5816341175723444727}
+  m_Father: {fileID: 5816341175208613869}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -70.469, y: 70.469}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5816341177092805437
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341177092805438}
+  m_CullTransparentMesh: 0
+--- !u!114 &5816341177092805436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5816341177092805438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0c9913652d6c1c54887c6cab3021a386, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Prefabs/UI/DummyPartUIBlock.prefab.meta
+++ b/Assets/Prefabs/UI/DummyPartUIBlock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff3ad0f3bf26b7947a71b52771e507fa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head.meta
+++ b/Assets/Scripts/Data/Dummies/Head.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6082c9b395aad0846951e3b8b0d0babd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPEar 1
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Ear01
+  m_displayIcon: {fileID: 21300000, guid: f79e6a6221b28f74dbaba1b11dc00ba5, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85d16f0c3dbfc5a48b5ccb7131f13a6c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHair 6
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hair06
+  m_displayIcon: {fileID: 21300000, guid: 3e5520e090310e84fb6a6720fec2f842, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a62ab001f3307b4eb30a2a99162f43e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHair 7
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hair07
+  m_displayIcon: {fileID: 21300000, guid: fb98ec44e6daf2b4682cc36b86a4b56a, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d6a252ee98a5074a9b5f6d306192bbe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHair 8
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hair08
+  m_displayIcon: {fileID: 21300000, guid: 43dd7c0e3deeb7446b064ac95e83d2f5, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 150f51d77a3ddbb49ba393b055e3162e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHair 9
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hair09
+  m_displayIcon: {fileID: 21300000, guid: ab7d1539bbdb179428ab23d9afd21bff, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a7cf2655e05bbe43a3e466fbdf9e134
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 16_noicon
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat16
+  m_displayIcon: {fileID: 21300000, guid: cfa160d5e1073db47a6f9cb786d004ba, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b6d0dae6dcd6454fb2a189d7379e421
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 17
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat17
+  m_displayIcon: {fileID: 21300000, guid: 2e9eb69b3e84e6d4eaff7f2c939998ae, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16c2551a5725b5f41a673b2f5d89c4f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 18
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat18
+  m_displayIcon: {fileID: 21300000, guid: 05477c5c1d5444f43a3142da5bdb2e7f, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6d36d917db229e4480326beb251e58b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 19
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat19
+  m_displayIcon: {fileID: 21300000, guid: 6071bcb4daaefff4d9c7fd8b6340f642, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18fed0de4272bbe4d82a5209a6d46018
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 20
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat20
+  m_displayIcon: {fileID: 21300000, guid: 8bb9a07e63cae8844853e4da2c366ad7, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 836515c6989cef14ca945170d8827ed3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHat 21
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Hat21
+  m_displayIcon: {fileID: 21300000, guid: 25e8e901c021c7e4a82ee09f3072c5a1, type: 3}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80746ab5936cd6b47adfbc67df333eb2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Horns.meta
+++ b/Assets/Scripts/Data/Dummies/Horns.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf2e2c9708c51ca46a4defade6a02c1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHorn 10
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Horn10
+  m_displayIcon: {fileID: 21300000, guid: 89c85886692bf7f4abc87413762603e5, type: 3}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea9f9f4691a02794191aabd359b0df13
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHorn 11
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Horn11
+  m_displayIcon: {fileID: 21300000, guid: cfa160d5e1073db47a6f9cb786d004ba, type: 3}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6db69e7a801f8d242b3d5aa7e1ebc904
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHorn 12
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Horn12
+  m_displayIcon: {fileID: 21300000, guid: 7f3eb1eba0b4d7a4db9669a467a01218, type: 3}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfe53d3027edb494fa86b8f2c6678981
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPHorn 13
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Horn13
+  m_displayIcon: {fileID: 21300000, guid: f79e6a6221b28f74dbaba1b11dc00ba5, type: 3}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd71b927c874dd945ba190192cf1ff08
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abc4dc91099a87f48bfd829abec22f76
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 1
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth01
+  m_displayIcon: {fileID: 21300000, guid: 838cc637cf5c30748b2fd6b45d1eefe6, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0f7997b4da96cf4b99e2495c623c719
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 15
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth15
+  m_displayIcon: {fileID: 21300000, guid: 808a2d3598da2984682adcfbc7ed6091, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8551bd04a51b3604d966c930244774c6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 2
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth02
+  m_displayIcon: {fileID: 21300000, guid: 6a30ba2f586b41045afcf3552d31faf2, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc93455795ee09c409a88426749569d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 3
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth03
+  m_displayIcon: {fileID: 21300000, guid: 20add1502d39b164aab76664308b0f55, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7b53bacfc336d24ca9ba392f6f80c5a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 4
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth04
+  m_displayIcon: {fileID: 21300000, guid: 4c7ae10d38515ca47b57762f874978ba, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b1cb980e4518854e96edc06fca579a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 5
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth05
+  m_displayIcon: {fileID: 21300000, guid: 0f0d640b766fc9b428fd42fa232a6f96, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 291a906386fb9cc4091b6e0d01a840de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 6
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth06
+  m_displayIcon: {fileID: 21300000, guid: 9cc2592152691114097e4e05529037d8, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f8bafe1c0402f640b52cacf718f63a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 7
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth07
+  m_displayIcon: {fileID: 21300000, guid: 1e8dc5d0f7c669e428794039dfbe1814, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1eed77d4f041e948b717320fbf521b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 8
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth08
+  m_displayIcon: {fileID: 21300000, guid: 57fdcb804002a0c449fa843ebfd1a83f, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ff270838ebdc574aa3930719efe2cee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPMouth 9
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Mouth09
+  m_displayIcon: {fileID: 21300000, guid: fc3b2b64e9c43a04a995434c0c173561, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82a3f036474a48448a9c4923a532b93a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPNose 10
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Nose10
+  m_displayIcon: {fileID: 21300000, guid: 3487c4b2a14ccfe40bf7b172ed875ec6, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 223cfe668fef74446aff51ed28b666a3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPNose 11
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Nose11
+  m_displayIcon: {fileID: 21300000, guid: d083486f26ff4cb40a541922c86930d5, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e912827653e76142b7dd6d267595303
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPNose 12
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Nose12
+  m_displayIcon: {fileID: 21300000, guid: 3487c4b2a14ccfe40bf7b172ed875ec6, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 03758ac947c613c46ae992e00d8dea59
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPNose 13
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Nose13
+  m_displayIcon: {fileID: 21300000, guid: 36f9c1b48662dd74a876b27de8acff4f, type: 3}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f131991e06099e4785d73cbb183ff18
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails.meta
+++ b/Assets/Scripts/Data/Dummies/Tails.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f081c4ee6c8235d4b92b1471101ac757
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 1
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail01
+  m_displayIcon: {fileID: 21300000, guid: d3e22f8bb9982e04aa49097bd9ce12df, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6aea43c676697924ea8cfc86c29c224b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 2
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail02
+  m_displayIcon: {fileID: 21300000, guid: f20f8fcf07e273340a22d5d2dc941432, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7ce5af91b726aa40affe39d9ec01099
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 3
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail03
+  m_displayIcon: {fileID: 21300000, guid: 98e4db46699989d43a0166b5d7b857f9, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dc895f74f31267499cf368a03dc65dc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 4
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail04
+  m_displayIcon: {fileID: 21300000, guid: b43c0ff709b5f894ea2b3f9dc0468a6e, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38bf5a24aa7d75543ac460782103e65e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 5
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail05
+  m_displayIcon: {fileID: 21300000, guid: bc26ca0c89c741c4eac03ceddce9401f, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d67d2935ada4bc249a7da6d65cad71be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 6
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail06
+  m_displayIcon: {fileID: 21300000, guid: 04bd1d74be0b6c94c884ae7d88973bcf, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 016db5e010b699a4ab2bc6bd14e96420
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 7
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail07
+  m_displayIcon: {fileID: 21300000, guid: fdbbcacedfa0ba94cab9099ab021841a, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cea3288ebde5d340b26126dcb82faed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
+  m_Name: GPTail 8
+  m_EditorClassIdentifier: 
+  m_gameObjectName: Tail08
+  m_displayIcon: {fileID: 21300000, guid: b0c475f7a183ed347957d092e8118baa, type: 3}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset.meta
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 357d2a97d008abc438f614705f36e74a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
+++ b/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
@@ -4,9 +4,61 @@ using UnityEngine;
 
 public class GPCustomizationTabScreen : GPGUIScreen
 {
+  public GPDummyCustomizationScreen m_customization;
+  public Transform m_container;
+  public List<GPDummyPartDesc> m_parts;
+  public GPDummyPartBlock m_blockPrefab;
+  [HideInInspector]
+  public List<GPDummyPartBlock> m_partBlocks = new List<GPDummyPartBlock>();
+  GPDummyPartBlock m_selectedBlock = null;
+
   // Start is called before the first frame update
   void Start()
   {
+    for (int i = 0; i < m_parts.Count; i++)
+    {
+      GPDummyPartBlock newBlock = Instantiate(m_blockPrefab, m_container);
+      newBlock.DisplayPart(m_parts[i]);
+      newBlock.OnSelectedEvent.AddListener(OnBlockSelected);
+      m_partBlocks.Add(newBlock);
+    }
 
+    if (m_partBlocks.Count > 0)
+    {
+      m_selectedBlock = m_partBlocks[0];
+    }
+  }
+
+  public void OnBlockSelected(GPDummyPartBlock block)
+  {
+    if (m_selectedBlock)
+    {
+      m_selectedBlock.TogglePin(false);
+      RecursiveFindChild(m_customization.m_dummyModelRef, m_selectedBlock.m_partDesc.m_gameObjectName).gameObject.SetActive(false);
+    }
+    m_selectedBlock = block;
+    m_selectedBlock.TogglePin(true);
+
+    RecursiveFindChild(m_customization.m_dummyModelRef, block.m_partDesc.m_gameObjectName).gameObject.SetActive(true);
+  }
+
+  Transform RecursiveFindChild(Transform parent, string childName)
+  {
+    foreach (Transform child in parent)
+    {
+      if (child.name == childName)
+      {
+        return child;
+      }
+      else
+      {
+        Transform found = RecursiveFindChild(child, childName);
+        if (found != null)
+        {
+          return found;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/Assets/Scripts/Menus/GPDummyCustomizationScreen.cs
+++ b/Assets/Scripts/Menus/GPDummyCustomizationScreen.cs
@@ -14,6 +14,9 @@ public class GPUITab
 
 public class GPDummyCustomizationScreen : GPGUIScreen
 {
+  [Header("Model Settings")]
+  public Transform m_dummyModelRef;
+
   [Header("Tab Settings")]
   public Transform m_tabFocusImage;
   public Color m_selectedTabColor;
@@ -69,4 +72,5 @@ public class GPDummyCustomizationScreen : GPGUIScreen
   {
     LeanTween.move(m_tabFocusImage.gameObject, targetTransform.position, 0.3f).setEaseSpring();
   }
+
 }

--- a/Assets/Scripts/UI/GPDummyPartBlock.cs
+++ b/Assets/Scripts/UI/GPDummyPartBlock.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+public class GPDummyPartBlock : MonoBehaviour
+{
+  public Image m_iconSprite;
+  public Image m_selectedPinImage;
+  public Button m_button;
+  [HideInInspector]
+  public GPDummyPartDesc m_partDesc;
+
+  public UnityEvent<GPDummyPartBlock> OnSelectedEvent;
+
+  // Start is called before the first frame update
+  void Start()
+  {
+    m_button.onClick.AddListener(OnSelected);
+    TogglePin(false);
+  }
+
+  public void DisplayPart(GPDummyPartDesc desc)
+  {
+    m_partDesc = desc;
+    m_iconSprite.sprite = desc.m_displayIcon;
+  }
+
+  public void TogglePin(bool active)
+  {
+    m_selectedPinImage.gameObject.SetActive(active);
+  }
+
+  public void OnSelected()
+  {
+    if (OnSelectedEvent != null)
+    {
+      OnSelectedEvent.Invoke(this);
+    }
+  }
+}

--- a/Assets/Scripts/UI/GPDummyPartBlock.cs.meta
+++ b/Assets/Scripts/UI/GPDummyPartBlock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c101a7f96084784e9037a94fcc135fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
-Scriptable objects for eyes, tails, Hair, Hats and Horns setted.
-Prefab for dummy part UI button added.
-Dummy part UI button are spawned in the menu at runtime based on the registered body part scriptable objects.
-Dummy customization screen now equips the body parts the user selects (skin, guantelets and clothes are still in progress).
-Pin icon appears on the currently equipped body parts buttons.