### PR TITLE
Dev mick

### DIFF
--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 1.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 1.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 1
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye01
   m_displayIcon: {fileID: 21300000, guid: 72e3c0e78e4ae474c88ddf9e349f62d9, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 10.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 10.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 10
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye10
   m_displayIcon: {fileID: 21300000, guid: 9d09dc55c419a22468f5f9fa30de4bdc, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 11.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 11.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 11
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye11
   m_displayIcon: {fileID: 21300000, guid: 4ebb2cc2d29b5a54bab898ba2ea0bc63, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 12.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 12.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 12
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye12
   m_displayIcon: {fileID: 21300000, guid: 4563687e6d4f18e45afa196dbea374e0, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 15.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 15.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 15
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye15
   m_displayIcon: {fileID: 21300000, guid: 7b204e11e98ca154c9b2979d265bd2a8, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 2.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 2.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 2
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye02
   m_displayIcon: {fileID: 21300000, guid: 2c3779bf64d0387498c8801a2e1d7cea, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 4.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 4.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 4
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye04
   m_displayIcon: {fileID: 21300000, guid: d5d1811c271e80d459189b01baf1f078, type: 3}
   m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 5.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 5.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 5
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye05
   m_displayIcon: {fileID: 21300000, guid: 9fae65dbcf7b16c4fa69632c1bfce77f, type: 3}
   m_material: {fileID: 2100000, guid: 5f7c030192f45df4fb9679db9b01d54e, type: 2}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 6.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 6.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 6
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye06
   m_displayIcon: {fileID: 21300000, guid: 6884d323c8215764aae16aa0e8f2214f, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 8.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 8.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 8
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye08
   m_displayIcon: {fileID: 21300000, guid: 6d1658d7b25d8284391e64e61bc569ac, type: 3}
   m_material: {fileID: 2100000, guid: 459c8f67743a04048b10282c748d2931, type: 2}

--- a/Assets/Scripts/Data/Dummies/Eyes/GPEye 9.asset
+++ b/Assets/Scripts/Data/Dummies/Eyes/GPEye 9.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEye 9
   m_EditorClassIdentifier: 
+  m_type: 1
   m_gameObjectName: Eye09
   m_displayIcon: {fileID: 21300000, guid: 52c72a59f706794438a357c05700a143, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/GPDummyLoader.cs
+++ b/Assets/Scripts/Data/Dummies/GPDummyLoader.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GPDummyLoader : MonoBehaviour
+{
+    public Transform m_dummyModelRef;
+    Vector3 m_originalScale;
+    Vector3 m_originalLocalEuler;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        ChangeAppearance(GPPlayerProfile.m_instance.m_dummySlots[GPPlayerProfile.m_instance.m_currDummySlotIdx]);
+    }
+
+    public void ChangeAppearance(GPDummyData data)
+    {
+        EquipCustomPart(data.m_skin);
+        EquipCustomPart(data.m_eye);
+        EquipCustomPart(data.m_mouth);
+        EquipCustomPart(data.m_hair);
+        EquipCustomPart(data.m_horns);
+        EquipCustomPart(data.m_wear);
+        EquipCustomPart(data.m_gloves);
+        EquipCustomPart(data.m_tail);
+    }
+
+    /// <summary>
+    /// Activates a dummy part on the dummy model.
+    /// </summary>
+    /// <param name="desc"></param>
+    /// <param name="animate"></param>
+    public void EquipCustomPart(GPDummyPartDesc desc, bool animate = true)
+    {
+        Transform part = RecursiveFindChild(m_dummyModelRef, desc.m_gameObjectName);
+        part.gameObject.SetActive(true);
+        if (desc.m_material != null)
+        {
+            part.GetComponent<Renderer>().material = desc.m_material;
+        }
+
+        if (animate)
+        {
+            LeanTween.scale(m_dummyModelRef.gameObject, m_originalScale - (Vector3.one * 0.2f), 0.4f).setEasePunch();
+        }
+    }
+
+    /// <summary>
+    /// Deactivates a dummy part on the dummy model
+    /// </summary>
+    /// <param name="desc"></param>
+    public void UnequipCustomPart(GPDummyPartDesc desc)
+    {
+        Transform part = RecursiveFindChild(m_dummyModelRef, desc.m_gameObjectName);
+        part.gameObject.SetActive(false);
+
+        m_dummyModelRef.gameObject.transform.localScale = m_originalScale;
+        LeanTween.scale(m_dummyModelRef.gameObject, m_originalScale - (Vector3.one * 0.2f), 0.4f).setEasePunch();
+    }
+
+    /// <summary>
+    /// Find a nested child of a transform that matchs the given child name.
+    /// </summary>
+    /// <param name="parent"></param>
+    /// <param name="childName"></param>
+    /// <returns></returns>
+    Transform RecursiveFindChild(Transform parent, string childName)
+    {
+        foreach (Transform child in parent)
+        {
+            if (child.name == childName)
+            {
+                return child;
+            }
+            else
+            {
+                Transform found = RecursiveFindChild(child, childName);
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/Assets/Scripts/Data/Dummies/GPDummyLoader.cs.meta
+++ b/Assets/Scripts/Data/Dummies/GPDummyLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed78bbde0c357a1409bad0e4511e849d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Dummies/GPDummyPartDesc.cs
+++ b/Assets/Scripts/Data/Dummies/GPDummyPartDesc.cs
@@ -2,9 +2,22 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+public enum GP_DUMMY_PART_TYPE
+{
+    kSkin,
+    kEye,
+    kMouth,
+    kHair,
+    kHorn,
+    kWear,
+    kGlove,
+    kTail,
+}
+
 [CreateAssetMenu(fileName = "GPDummyPartDesc", menuName = "ScriptableObjects/GPDummyPartDesc")]
 public class GPDummyPartDesc : ScriptableObject
 {
+    public GP_DUMMY_PART_TYPE m_type;
     [Tooltip("Name of the game object to activate in the dummy gameobject")]
     public string m_gameObjectName; // All parts are already nested in the dummy gameobject, so we just find it and activate it.
     public Sprite m_displayIcon; // Icon that shows in the customziation menu.

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 1.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 1
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove01
   m_displayIcon: {fileID: 21300000, guid: 7b7a240e02d80e940950d593dd7b7cea, type: 3}
   m_material: {fileID: 2100000, guid: 0c27c424e1379dc498960d2360aa8505, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 10.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 10.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 10
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove10
   m_displayIcon: {fileID: 21300000, guid: 564885a4d3c4afb4792ae4fbc8e0edce, type: 3}
   m_material: {fileID: 2100000, guid: 5a17c43e72cd804478f3f11fe8b5b90c, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 2.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 2.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 2
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove02
   m_displayIcon: {fileID: 21300000, guid: 8bca7918b82aaea4e9b4bc6a1a46fc20, type: 3}
   m_material: {fileID: 2100000, guid: b876c6ab6cae1f64fb3e1de63a035521, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 3.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 3.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 3
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove03
   m_displayIcon: {fileID: 21300000, guid: 08886fb5ede610545ac103f580b8dbe3, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 4.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 4.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 4
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove04
   m_displayIcon: {fileID: 21300000, guid: bd5cfa19cc641084ca9e4843f502b2f5, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 5.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 5.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 5
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove05
   m_displayIcon: {fileID: 21300000, guid: 889583555d7db6848b8476353b088c60, type: 3}
   m_material: {fileID: 2100000, guid: 4fee6b3fcf3e41f47a91f18e010e769a, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 6.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 6.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 6
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove06
   m_displayIcon: {fileID: 21300000, guid: 149877e959ab7554ab8cd620a8ae0f85, type: 3}
   m_material: {fileID: 2100000, guid: befc71491ec3d73458531c66e88470f2, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 7.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 7.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 7
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove07
   m_displayIcon: {fileID: 21300000, guid: f89482d9fb86bf04c826b117ece7c347, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 8.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 8.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 8
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove08
   m_displayIcon: {fileID: 21300000, guid: 38f12e0c4726f984d83ba2b34563194f, type: 3}
   m_material: {fileID: 2100000, guid: b3bde756aa427584ca7f515b775daa19, type: 2}

--- a/Assets/Scripts/Data/Dummies/Gloves/GPGlove 9.asset
+++ b/Assets/Scripts/Data/Dummies/Gloves/GPGlove 9.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPGlove 9
   m_EditorClassIdentifier: 
+  m_type: 6
   m_gameObjectName: Glove09
   m_displayIcon: {fileID: 21300000, guid: 48c5d3b634d6db94fa1f6fee95c41a9e, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPEar 1.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPEar 1
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Ear01
   m_displayIcon: {fileID: 21300000, guid: f79e6a6221b28f74dbaba1b11dc00ba5, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHair 6
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hair06
   m_displayIcon: {fileID: 21300000, guid: 3e5520e090310e84fb6a6720fec2f842, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 7.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHair 7
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hair07
   m_displayIcon: {fileID: 21300000, guid: fb98ec44e6daf2b4682cc36b86a4b56a, type: 3}
   m_material: {fileID: 2100000, guid: 9e1b8f12dfbe1e84983945250907c628, type: 2}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 8.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHair 8
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hair08
   m_displayIcon: {fileID: 21300000, guid: 43dd7c0e3deeb7446b064ac95e83d2f5, type: 3}
   m_material: {fileID: 2100000, guid: 9d762caaab21b8742a274d33f80b8fef, type: 2}

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 9.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHair 9
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hair09
   m_displayIcon: {fileID: 21300000, guid: ab7d1539bbdb179428ab23d9afd21bff, type: 3}
   m_material: {fileID: 2100000, guid: 17496d2caed56ae4d8c7a3c711261e7c, type: 2}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 16_noicon.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 16_noicon
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat16
   m_displayIcon: {fileID: 21300000, guid: cfa160d5e1073db47a6f9cb786d004ba, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 17.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 17
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat17
   m_displayIcon: {fileID: 21300000, guid: 2e9eb69b3e84e6d4eaff7f2c939998ae, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 18.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 18
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat18
   m_displayIcon: {fileID: 21300000, guid: 05477c5c1d5444f43a3142da5bdb2e7f, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 19.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 19
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat19
   m_displayIcon: {fileID: 21300000, guid: 6071bcb4daaefff4d9c7fd8b6340f642, type: 3}
   m_material: {fileID: 2100000, guid: 83cee94dce5cc6949979110cc15a5bd8, type: 2}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 20.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 20
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat20
   m_displayIcon: {fileID: 21300000, guid: 8bb9a07e63cae8844853e4da2c366ad7, type: 3}
   m_material: {fileID: 2100000, guid: 42c59779cb4ba2946b5c8c83de471280, type: 2}

--- a/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHat 21.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHat 21
   m_EditorClassIdentifier: 
+  m_type: 3
   m_gameObjectName: Hat21
   m_displayIcon: {fileID: 21300000, guid: 25e8e901c021c7e4a82ee09f3072c5a1, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 10.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHorn 10
   m_EditorClassIdentifier: 
+  m_type: 4
   m_gameObjectName: Horn10
   m_displayIcon: {fileID: 21300000, guid: 89c85886692bf7f4abc87413762603e5, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 11.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHorn 11
   m_EditorClassIdentifier: 
+  m_type: 4
   m_gameObjectName: Horn11
   m_displayIcon: {fileID: 21300000, guid: cfa160d5e1073db47a6f9cb786d004ba, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 12.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHorn 12
   m_EditorClassIdentifier: 
+  m_type: 4
   m_gameObjectName: Horn12
   m_displayIcon: {fileID: 21300000, guid: 7f3eb1eba0b4d7a4db9669a467a01218, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPHorn 13.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPHorn 13
   m_EditorClassIdentifier: 
+  m_type: 4
   m_gameObjectName: Horn13
   m_displayIcon: {fileID: 21300000, guid: f79e6a6221b28f74dbaba1b11dc00ba5, type: 3}
   m_material: {fileID: 2100000, guid: 563b869b2c9768c4b987831907fe45f6, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 1.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 1
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth01
   m_displayIcon: {fileID: 21300000, guid: 838cc637cf5c30748b2fd6b45d1eefe6, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 15.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 15
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth15
   m_displayIcon: {fileID: 21300000, guid: 808a2d3598da2984682adcfbc7ed6091, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 2.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 2
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth02
   m_displayIcon: {fileID: 21300000, guid: 6a30ba2f586b41045afcf3552d31faf2, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 3.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 3
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth03
   m_displayIcon: {fileID: 21300000, guid: 20add1502d39b164aab76664308b0f55, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 4.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 4
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth04
   m_displayIcon: {fileID: 21300000, guid: 4c7ae10d38515ca47b57762f874978ba, type: 3}
   m_material: {fileID: 2100000, guid: 8cdf4f1cdd1757f4b96cd964a5da9e97, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 5.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 5
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth05
   m_displayIcon: {fileID: 21300000, guid: 0f0d640b766fc9b428fd42fa232a6f96, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 6.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 6
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth06
   m_displayIcon: {fileID: 21300000, guid: 9cc2592152691114097e4e05529037d8, type: 3}
   m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 7.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 7
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth07
   m_displayIcon: {fileID: 21300000, guid: 1e8dc5d0f7c669e428794039dfbe1814, type: 3}
   m_material: {fileID: 2100000, guid: 860e3165b0ef2b64bacd9f49802a4a05, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 8.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 8
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth08
   m_displayIcon: {fileID: 21300000, guid: 57fdcb804002a0c449fa843ebfd1a83f, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPMouth 9.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPMouth 9
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Mouth09
   m_displayIcon: {fileID: 21300000, guid: fc3b2b64e9c43a04a995434c0c173561, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 10.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPNose 10
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Nose10
   m_displayIcon: {fileID: 21300000, guid: 3487c4b2a14ccfe40bf7b172ed875ec6, type: 3}
   m_material: {fileID: 2100000, guid: 29aaf770ee78cc84588cbf761fa4b8d7, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 11.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPNose 11
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Nose11
   m_displayIcon: {fileID: 21300000, guid: d083486f26ff4cb40a541922c86930d5, type: 3}
   m_material: {fileID: 2100000, guid: bb39131befa338d4f8a9895df4af720b, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 12.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPNose 12
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Nose12
   m_displayIcon: {fileID: 21300000, guid: f3e07112ff2d17540b345b39d1b65d3f, type: 3}
   m_material: {fileID: 2100000, guid: 7b81ebe5e5f0b3044b66df14d0a5ea43, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 13.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPNose 13
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Nose13
   m_displayIcon: {fileID: 21300000, guid: 3487c4b2a14ccfe40bf7b172ed875ec6, type: 3}
   m_material: {fileID: 2100000, guid: 255ce66ce6aca8a458e81c15ffa8ebef, type: 2}

--- a/Assets/Scripts/Data/Dummies/Mouths/GPNose 14.asset
+++ b/Assets/Scripts/Data/Dummies/Mouths/GPNose 14.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPNose 14
   m_EditorClassIdentifier: 
+  m_type: 2
   m_gameObjectName: Nose14
   m_displayIcon: {fileID: 21300000, guid: 36f9c1b48662dd74a876b27de8acff4f, type: 3}
   m_material: {fileID: 2100000, guid: a7593083d807ae442b3c4ebe0cb19a32, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 1
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail01
   m_displayIcon: {fileID: 21300000, guid: d3e22f8bb9982e04aa49097bd9ce12df, type: 3}
   m_material: {fileID: 2100000, guid: 47b49f8c1868bac428495a76b77cf1fc, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 2.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 2
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail02
   m_displayIcon: {fileID: 21300000, guid: f20f8fcf07e273340a22d5d2dc941432, type: 3}
   m_material: {fileID: 2100000, guid: 23497093f030e334cb6f2d68fcf7b658, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 3.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 3
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail03
   m_displayIcon: {fileID: 21300000, guid: 98e4db46699989d43a0166b5d7b857f9, type: 3}
   m_material: {fileID: 2100000, guid: 53aa45e702ff3b44783795be59754bf3, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 4.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 4
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail04
   m_displayIcon: {fileID: 21300000, guid: b43c0ff709b5f894ea2b3f9dc0468a6e, type: 3}
   m_material: {fileID: 2100000, guid: cb32192854568e04fb159655246e943b, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 5.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 5
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail05
   m_displayIcon: {fileID: 21300000, guid: bc26ca0c89c741c4eac03ceddce9401f, type: 3}
   m_material: {fileID: 2100000, guid: 3897eb8b29768b84c9ada40d5bc8fb71, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 6.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 6
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail06
   m_displayIcon: {fileID: 21300000, guid: 04bd1d74be0b6c94c884ae7d88973bcf, type: 3}
   m_material: {fileID: 2100000, guid: 8b15547de7df9c942bf12b4ddbe614ad, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 7.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 7
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail07
   m_displayIcon: {fileID: 21300000, guid: fdbbcacedfa0ba94cab9099ab021841a, type: 3}
   m_material: {fileID: 2100000, guid: 9a52a86cfa67401429a7ccd1b26d21f2, type: 2}

--- a/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset
+++ b/Assets/Scripts/Data/Dummies/Tails/GPTail 8.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPTail 8
   m_EditorClassIdentifier: 
+  m_type: 7
   m_gameObjectName: Tail08
   m_displayIcon: {fileID: 21300000, guid: b0c475f7a183ed347957d092e8118baa, type: 3}
   m_material: {fileID: 2100000, guid: 80d8920eba0a7ba4f8d00d96dc8fcbd1, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 1.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 1
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart01
   m_displayIcon: {fileID: 21300000, guid: e7dbcc4947cf1fd4ca3a7f43ed31bbc2, type: 3}
   m_material: {fileID: 2100000, guid: 8c84788f2bc3d2f42a2b16c5ea389455, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 10.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 10.asset
@@ -12,5 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 10
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart10
   m_displayIcon: {fileID: 21300000, guid: 981fbee9ac9bdf844bd70ba828fb3dcc, type: 3}
+  m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 2.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 2.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 2
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart02
   m_displayIcon: {fileID: 21300000, guid: 24a7b6de924459949b5398da130e2a28, type: 3}
   m_material: {fileID: 2100000, guid: 9567e9c89da3c9a43b28df65b2ed630b, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 3.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 3.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 3
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart03
   m_displayIcon: {fileID: 21300000, guid: c5efe8c28c7a5c447a77c36f2bdee61a, type: 3}
   m_material: {fileID: 2100000, guid: fa3871c3befb6c046bc2d562ce5bbc6e, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 4.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 4.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 4
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart04
   m_displayIcon: {fileID: 21300000, guid: cf343e329fe2d0e4597acba2a2a40f5c, type: 3}
   m_material: {fileID: 2100000, guid: 566c66035c6e606458cf4d264232816b, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 5.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 5.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 5
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart05
   m_displayIcon: {fileID: 21300000, guid: e342185903e14ab4ebae162df5bff7bf, type: 3}
   m_material: {fileID: 2100000, guid: a33d9d9640f7402469be2efcf6ca51eb, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 6.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 6.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 6
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart06
   m_displayIcon: {fileID: 21300000, guid: 475c73b3c19d034448b1decca5f548fb, type: 3}
   m_material: {fileID: 2100000, guid: e33120211f72a1f4fa38bb12136147f5, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 7.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 7.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 7
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart07
   m_displayIcon: {fileID: 21300000, guid: bb1e202dfc0caf7469edb4d0ef22da64, type: 3}
   m_material: {fileID: 2100000, guid: c6b854288084fed4fa31f05254c95392, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 8.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 8.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 8
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart08
   m_displayIcon: {fileID: 21300000, guid: b551e6eacae3be24c9ab2ff84e46b8e2, type: 3}
   m_material: {fileID: 2100000, guid: 8ae618a474e5b35468e19b1c53c5b30f, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 9.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 9.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce1c6f1fc131ab479ddbe791a266564, type: 3}
   m_Name: GPWear 9
   m_EditorClassIdentifier: 
+  m_type: 5
   m_gameObjectName: Bodypart09
   m_displayIcon: {fileID: 21300000, guid: 6cb1bef7d36aa2e4890417fcbf7e4de1, type: 3}
   m_material: {fileID: 2100000, guid: 190974efc015c1644af79cbdba26699c, type: 2}

--- a/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
+++ b/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
@@ -4,26 +4,14 @@ using UnityEngine;
 
 public class GPCustomizationTabScreen : GPGUIScreen
 {
-    public enum GP_CSTOMIZATION_TYPE
-    {
-        kSkin,
-        kEyes,
-        kMouth,
-        kHair,
-        kHorns,
-        kWear,
-        kGloves,
-        kTail
-    }
-
-    public GP_CSTOMIZATION_TYPE m_type;
+    public GP_DUMMY_PART_TYPE m_type;
 
     [Header("Screen references")]
     public GPDummyCustomizationScreen m_customization;
 
     [Header("Customization menu references")]
     public Transform m_container; // where parts buttons will be parented
-    public List<GPDummyPartDesc> m_parts;
+    private List<GPDummyPartDesc> m_parts;
     public GPDummyPartBlock m_blockPrefab; // part button prefab
     [HideInInspector]
     public List<GPDummyPartBlock> m_partBlocks = new List<GPDummyPartBlock>(); // store the instanced part buttons
@@ -45,6 +33,36 @@ public class GPCustomizationTabScreen : GPGUIScreen
     // Start is called before the first frame update
     void Start()
     {
+        switch (m_type)
+        {
+            case GP_DUMMY_PART_TYPE.kSkin:
+                m_parts = GPPlayerProfile.m_instance.m_dummySkins;
+                break;
+            case GP_DUMMY_PART_TYPE.kEye:
+                m_parts = GPPlayerProfile.m_instance.m_dummyEyes;
+                break;
+            case GP_DUMMY_PART_TYPE.kMouth:
+                m_parts = GPPlayerProfile.m_instance.m_dummyMouths;
+                break;
+            case GP_DUMMY_PART_TYPE.kHair:
+                m_parts = GPPlayerProfile.m_instance.m_dummyHairs;
+                break;
+            case GP_DUMMY_PART_TYPE.kHorn:
+                m_parts = GPPlayerProfile.m_instance.m_dummyHorns;
+                break;
+            case GP_DUMMY_PART_TYPE.kWear:
+                m_parts = GPPlayerProfile.m_instance.m_dummyWears;
+                break;
+            case GP_DUMMY_PART_TYPE.kGlove:
+                m_parts = GPPlayerProfile.m_instance.m_dummyGloves;
+                break;
+            case GP_DUMMY_PART_TYPE.kTail:
+                m_parts = GPPlayerProfile.m_instance.m_dummyTails;
+                break;
+            default:
+                break;
+        }
+
         for (int i = 0; i < m_parts.Count; i++)
         {
             GPDummyPartBlock newBlock = Instantiate(m_blockPrefab, m_container);
@@ -69,6 +87,8 @@ public class GPCustomizationTabScreen : GPGUIScreen
         }
 
         m_customization.m_customizationSlot.Rotate(m_dummyRotation);
+
+        UpdatePins();
     }
 
     /// <summary>
@@ -91,6 +111,36 @@ public class GPCustomizationTabScreen : GPGUIScreen
             m_selectedBlock.TogglePin(true);
 
             m_customization.m_customizationSlot.EquipCustomPart(block.m_partDesc);
+
+            switch (block.m_partDesc.m_type)
+            {
+                case GP_DUMMY_PART_TYPE.kSkin:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_skin = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kEye:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_eye = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kMouth:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_mouth = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kHair:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_hair = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kHorn:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_horns = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kWear:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_wear = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kGlove:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_gloves = block.m_partDesc;
+                    break;
+                case GP_DUMMY_PART_TYPE.kTail:
+                    m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_tail = block.m_partDesc;
+                    break;
+                default:
+                    break;
+            }
 
             TanksMP.AudioManager.Play2D(m_equipSFX);
         }
@@ -126,5 +176,87 @@ public class GPCustomizationTabScreen : GPGUIScreen
             }
         }
         return null;
+    }
+
+    public GPDummyPartBlock FindBlockOfPartDesc(GPDummyPartDesc desc)
+    {
+        for (int i = 0; i < m_partBlocks.Count; i++)
+        {
+            if (m_partBlocks[i].m_partDesc == desc)
+            {
+                return m_partBlocks[i];
+            }
+        }
+
+        return null;
+    }
+
+    void UpdatePins()
+    {
+        //disable other pins
+        foreach (var blockPart in m_partBlocks)
+        {
+            blockPart.TogglePin(false);
+        }
+
+        //activate the pin of the equipped part
+        GPDummyPartBlock block = null;
+        switch (m_type)
+        {
+            case GP_DUMMY_PART_TYPE.kSkin:
+                {
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_skin);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kEye:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_eye);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kMouth:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_mouth);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kHair:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_hair);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kHorn:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_horns);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kWear:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_wear);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kGlove:
+                {
+
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_gloves);
+                    break;
+                }
+            case GP_DUMMY_PART_TYPE.kTail:
+                {
+                    block = FindBlockOfPartDesc(m_customization.m_dummyScreen.m_selectedSlot.m_savedData.m_tail);
+                    break;
+                }
+            default:
+                break;
+        }
+
+        if (block)
+        {
+            m_selectedBlock = block;
+            block.TogglePin(true);
+        }
     }
 }

--- a/Assets/Scripts/Menus/GPDummyScreen.cs
+++ b/Assets/Scripts/Menus/GPDummyScreen.cs
@@ -11,7 +11,8 @@ public class GPDummyScreen : GPGUIScreen
 
     [Header("Dummy slots references")]
     public List<GPDummySlotCard> m_dummySlots;
-    GPDummySlotCard m_selectedSlot;
+    [HideInInspector]
+    public GPDummySlotCard m_selectedSlot;
 
     // Start is called before the first frame update
     void Start()
@@ -95,6 +96,8 @@ public class GPDummyScreen : GPGUIScreen
         if (m_selectedSlot)
         {
             m_selectedSlot.ReplaceModelObject(m_dummyCustomizingScreen.m_customizationSlot.m_dummyModelRef);
+            int slotIdx = m_dummySlots.IndexOf(m_selectedSlot);
+            GPPlayerProfile.m_instance.m_dummySlots[slotIdx] = m_selectedSlot.m_savedData;
         }
     }
 }

--- a/Assets/Scripts/Systems/GPItemsDB.cs
+++ b/Assets/Scripts/Systems/GPItemsDB.cs
@@ -1,0 +1,81 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GPItemsDB : MonoBehaviour
+{
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummySkins = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyEyes = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyMouths = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyHairs = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyHorns = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyWears = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyGloves = new List<GPDummyPartDesc>();
+    [SerializeField]
+    List<GPDummyPartDesc> m_dummyTails = new List<GPDummyPartDesc>();
+
+    public Dictionary<string, GPDummyPartDesc> m_dummyPartsMap = new Dictionary<string, GPDummyPartDesc>();
+
+    public static GPItemsDB m_instance;
+
+    private void Awake()
+    {
+        if (m_instance == null)
+        {
+            m_instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        for (int i = 0; i < m_dummySkins.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummySkins[i].name, m_dummySkins[i]);
+        }
+
+        for (int i = 0; i < m_dummyEyes.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyEyes[i].name, m_dummyEyes[i]);
+        }
+
+        for (int i = 0; i < m_dummyMouths.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyMouths[i].name, m_dummyMouths[i]);
+        }
+
+        for (int i = 0; i < m_dummyHairs.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyHairs[i].name, m_dummyHairs[i]);
+        }
+
+        for (int i = 0; i < m_dummyHorns.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyHorns[i].name, m_dummyHorns[i]);
+        }
+
+        for (int i = 0; i < m_dummyWears.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyWears[i].name, m_dummyWears[i]);
+        }
+
+        for (int i = 0; i < m_dummyGloves.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyGloves[i].name, m_dummyGloves[i]);
+        }
+
+        for (int i = 0; i < m_dummyTails.Count; i++)
+        {
+            m_dummyPartsMap.Add(m_dummyTails[i].name, m_dummyTails[i]);
+        }
+    }
+}

--- a/Assets/Scripts/Systems/GPItemsDB.cs.meta
+++ b/Assets/Scripts/Systems/GPItemsDB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd55b0f1dc0c3954784c958f8e085098
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/GPPlayerProfile.cs
+++ b/Assets/Scripts/Systems/GPPlayerProfile.cs
@@ -19,7 +19,17 @@ public class GPPlayerProfile : MonoBehaviour
     [Header("Owned items settings")]
     public List<GPStoreChestSO> m_chests;
     public List<GPShipDesc> m_ships;
-    public List<GPDummyPartDesc> m_dummyParts;
+    public List<GPDummyPartDesc> m_dummySkins;
+    public List<GPDummyPartDesc> m_dummyEyes;
+    public List<GPDummyPartDesc> m_dummyMouths;
+    public List<GPDummyPartDesc> m_dummyHairs;
+    public List<GPDummyPartDesc> m_dummyHorns;
+    public List<GPDummyPartDesc> m_dummyWears;
+    public List<GPDummyPartDesc> m_dummyGloves;
+    public List<GPDummyPartDesc> m_dummyTails;
+
+    public List<GPDummyData> m_dummySlots = new List<GPDummyData>();
+    public int m_currDummySlotIdx = 0;
 
     public static GPPlayerProfile m_instance;
 

--- a/Assets/Scripts/UI/GPDummySlotCard.cs
+++ b/Assets/Scripts/UI/GPDummySlotCard.cs
@@ -15,6 +15,7 @@ public class GPDummySlotCard : MonoBehaviour
     public bool m_selected = false;
     Vector3 m_originalScale;
     Vector3 m_originalLocalEuler;
+    public GPDummyData m_savedData;
 
     void Awake()
     {


### PR DESCRIPTION
-Player profile class now stores the dummy parts that the user owns.
-The dummy customization menu now only shows the parts that the user owns.
-Class for obtaining references to dummy parts using a hash map added (will be used to recreate the customized dummy of every player in the battle).
-Class for storing the dummy customization data added.
-Player profile class now also stores the data of all his customized dummies.
-Bug fixed where the pin icon of the equiped dummy part didn't update when switching to another dummy slot.
-Created a script for recreating a dummy model based on the customization data saved on the player profile class (will be used to recreate the dummy in battle)