### PR TITLE
Dev mick

### DIFF
--- a/Assets/Prefabs/Systems/PlayerProfileData.prefab
+++ b/Assets/Prefabs/Systems/PlayerProfileData.prefab
@@ -1,0 +1,150 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2649231879992536909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2649231879992536907}
+  - component: {fileID: 2649231879992536908}
+  m_Layer: 0
+  m_Name: PlayerProfileData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2649231879992536907
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2649231879992536909}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 195.8995, y: 591.91345, z: 55.312}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2649231879992536908
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2649231879992536909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f623aa5b8b02ea40b1075fcf3d8d429, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_energy: 10
+  m_maxEnergy: 10
+  OnEnergyModifiedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_chests: []
+  m_ships: []
+  m_dummySkins:
+  - {fileID: 11400000, guid: 3c045b67211a54b45ba68cb14e423314, type: 2}
+  - {fileID: 11400000, guid: 4a99a63057e4ad440837e9dcaa3e5ea2, type: 2}
+  - {fileID: 11400000, guid: 3ad28eb362249834f9defcff51c8da39, type: 2}
+  - {fileID: 11400000, guid: f92dacf792633be48be32f2f9019a07f, type: 2}
+  - {fileID: 11400000, guid: a02ef28aa7d6ffa42a62e4109cb37fa3, type: 2}
+  - {fileID: 11400000, guid: 7cdeff818b8b9f04db317e2146610d69, type: 2}
+  - {fileID: 11400000, guid: e75e80ae94fc6f041a5d076381b0d3aa, type: 2}
+  - {fileID: 11400000, guid: 761dc3d806c0c654a9a11d5e45d2ad6b, type: 2}
+  - {fileID: 11400000, guid: 1dd1b02aaa9fbb2458da21e49c9a1180, type: 2}
+  - {fileID: 11400000, guid: 1afc09af0592e9843926ae818727b019, type: 2}
+  - {fileID: 11400000, guid: 25e8e92a731804a4fa2e553ba501f10a, type: 2}
+  - {fileID: 11400000, guid: 89c2ad30bb44cfd41806277a0f479935, type: 2}
+  - {fileID: 11400000, guid: ddec393f34ae2134d9459332ca70260c, type: 2}
+  - {fileID: 11400000, guid: 2c22a3c7a5cc6834ebe2e021edf4970e, type: 2}
+  - {fileID: 11400000, guid: af9d3e54cbf50834a870b4b1d73c0067, type: 2}
+  - {fileID: 11400000, guid: da1342b927b51384e82ee41b03c868a3, type: 2}
+  - {fileID: 11400000, guid: b91eeee71de3e4845a18822acce9e69c, type: 2}
+  - {fileID: 11400000, guid: 96d17d2ba407d954eb2acd3f2cbce6aa, type: 2}
+  - {fileID: 11400000, guid: 4d851705c88e7f64a93ee8b72f98333d, type: 2}
+  m_dummyEyes:
+  - {fileID: 11400000, guid: 41250bb9d8d6cb64cab9ca25a2a9d808, type: 2}
+  - {fileID: 11400000, guid: ebd409e3fc4f354459ddab7fce9250e3, type: 2}
+  - {fileID: 11400000, guid: c6352502bab7afb46a05d99529dddf00, type: 2}
+  - {fileID: 11400000, guid: 36300bf799b7d8f4b8d818a7b88c841f, type: 2}
+  - {fileID: 11400000, guid: 64eac6fcdeed8374093634ab794c393f, type: 2}
+  - {fileID: 11400000, guid: 2429019846956c54c9a94bca6304b97c, type: 2}
+  - {fileID: 11400000, guid: 7d9f943c9be828f45bf4f0b1d1cedfd4, type: 2}
+  - {fileID: 11400000, guid: 0e06d0dacfe220e439e2192432596b52, type: 2}
+  - {fileID: 11400000, guid: cd781b7b6635ec04e9146538e71db4b2, type: 2}
+  - {fileID: 11400000, guid: 0914a56a783e36a46837c1c3e05c4cba, type: 2}
+  - {fileID: 11400000, guid: 8f0b1fcda647a9c44a3f11f29f7a67ce, type: 2}
+  m_dummyMouths:
+  - {fileID: 11400000, guid: b0f7997b4da96cf4b99e2495c623c719, type: 2}
+  - {fileID: 11400000, guid: fc93455795ee09c409a88426749569d3, type: 2}
+  - {fileID: 11400000, guid: c7b53bacfc336d24ca9ba392f6f80c5a, type: 2}
+  - {fileID: 11400000, guid: 9b1cb980e4518854e96edc06fca579a0, type: 2}
+  - {fileID: 11400000, guid: 291a906386fb9cc4091b6e0d01a840de, type: 2}
+  - {fileID: 11400000, guid: 5f8bafe1c0402f640b52cacf718f63a9, type: 2}
+  - {fileID: 11400000, guid: a1eed77d4f041e948b717320fbf521b0, type: 2}
+  - {fileID: 11400000, guid: 2ff270838ebdc574aa3930719efe2cee, type: 2}
+  - {fileID: 11400000, guid: 82a3f036474a48448a9c4923a532b93a, type: 2}
+  - {fileID: 11400000, guid: 8551bd04a51b3604d966c930244774c6, type: 2}
+  - {fileID: 11400000, guid: 223cfe668fef74446aff51ed28b666a3, type: 2}
+  - {fileID: 11400000, guid: 4e912827653e76142b7dd6d267595303, type: 2}
+  - {fileID: 11400000, guid: 03758ac947c613c46ae992e00d8dea59, type: 2}
+  - {fileID: 11400000, guid: 5f131991e06099e4785d73cbb183ff18, type: 2}
+  - {fileID: 11400000, guid: f033e79bac337c44f819f2c279c287e9, type: 2}
+  m_dummyHairs:
+  - {fileID: 11400000, guid: 1a62ab001f3307b4eb30a2a99162f43e, type: 2}
+  - {fileID: 11400000, guid: 7d6a252ee98a5074a9b5f6d306192bbe, type: 2}
+  - {fileID: 11400000, guid: 150f51d77a3ddbb49ba393b055e3162e, type: 2}
+  - {fileID: 11400000, guid: 4a7cf2655e05bbe43a3e466fbdf9e134, type: 2}
+  - {fileID: 11400000, guid: 16c2551a5725b5f41a673b2f5d89c4f8, type: 2}
+  - {fileID: 11400000, guid: b6d36d917db229e4480326beb251e58b, type: 2}
+  - {fileID: 11400000, guid: 18fed0de4272bbe4d82a5209a6d46018, type: 2}
+  - {fileID: 11400000, guid: 836515c6989cef14ca945170d8827ed3, type: 2}
+  - {fileID: 11400000, guid: 80746ab5936cd6b47adfbc67df333eb2, type: 2}
+  m_dummyHorns:
+  - {fileID: 11400000, guid: ea9f9f4691a02794191aabd359b0df13, type: 2}
+  - {fileID: 11400000, guid: 6db69e7a801f8d242b3d5aa7e1ebc904, type: 2}
+  - {fileID: 11400000, guid: cfe53d3027edb494fa86b8f2c6678981, type: 2}
+  - {fileID: 11400000, guid: dd71b927c874dd945ba190192cf1ff08, type: 2}
+  m_dummyWears:
+  - {fileID: 11400000, guid: dd8fa9bc40c9bfa40b41975df5726f69, type: 2}
+  - {fileID: 11400000, guid: ee00bf7af23dc0b40aeb80ae801e669a, type: 2}
+  - {fileID: 11400000, guid: 058c94b8cce36f94b8ea20ed5139f3a1, type: 2}
+  - {fileID: 11400000, guid: ff605ab0039767a46880c2e4e6904490, type: 2}
+  - {fileID: 11400000, guid: 3f06f492a3dd2b74a8253ab247e253b6, type: 2}
+  - {fileID: 11400000, guid: 66c20a0a4059d594a94c41b75ba6ef98, type: 2}
+  - {fileID: 11400000, guid: 297bbfee75871954192376b181e1d35a, type: 2}
+  - {fileID: 11400000, guid: c95f7120852d94d4fa25059e50d5c35a, type: 2}
+  - {fileID: 11400000, guid: 35c72cc63f8c8fe4ebcfaca32a85bfe2, type: 2}
+  - {fileID: 11400000, guid: d524aad38aee2de459c15635ab839a91, type: 2}
+  m_dummyGloves:
+  - {fileID: 11400000, guid: d6194dd804f5bc646bd446fc8b44e0b8, type: 2}
+  - {fileID: 11400000, guid: 8d3059bdbdcd56f4fbf3c7bcad05ccba, type: 2}
+  - {fileID: 11400000, guid: fbdbfd6eaf98db346b75de3454bb51a9, type: 2}
+  - {fileID: 11400000, guid: 1ad50aca28c17aa4891126501b444822, type: 2}
+  - {fileID: 11400000, guid: 392fceb7f063b154f8a98e3d017f4953, type: 2}
+  - {fileID: 11400000, guid: 6dcdcd0595f2dd342816becb4c57dc6a, type: 2}
+  - {fileID: 11400000, guid: 9771e35dc39acd244b52fd298a8b8296, type: 2}
+  - {fileID: 11400000, guid: c2561db0bb9d5dd4c959f47d0abf1c51, type: 2}
+  - {fileID: 11400000, guid: c46e85f381b5868409d51cee82323323, type: 2}
+  - {fileID: 11400000, guid: 8c7ea63804151694a8d6b90f8f0701ce, type: 2}
+  m_dummyTails:
+  - {fileID: 11400000, guid: 6aea43c676697924ea8cfc86c29c224b, type: 2}
+  - {fileID: 11400000, guid: c7ce5af91b726aa40affe39d9ec01099, type: 2}
+  - {fileID: 11400000, guid: 6dc895f74f31267499cf368a03dc65dc, type: 2}
+  - {fileID: 11400000, guid: 38bf5a24aa7d75543ac460782103e65e, type: 2}
+  - {fileID: 11400000, guid: d67d2935ada4bc249a7da6d65cad71be, type: 2}
+  - {fileID: 11400000, guid: 016db5e010b699a4ab2bc6bd14e96420, type: 2}
+  - {fileID: 11400000, guid: 8cea3288ebde5d340b26126dcb82faed, type: 2}
+  - {fileID: 11400000, guid: 357d2a97d008abc438f614705f36e74a, type: 2}
+  OnDummyPartsModifiedEvent:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Prefabs/Systems/PlayerProfileData.prefab.meta
+++ b/Assets/Prefabs/Systems/PlayerProfileData.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e3f6f48925e63b54f86e22a59124ebdf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Store/Chests/Epic Chest.asset
+++ b/Assets/Scripts/Data/Store/Chests/Epic Chest.asset
@@ -21,3 +21,6 @@ MonoBehaviour:
   m_gemPrice: 450
   m_specialTag: 0
   m_chestIcon: {fileID: 21300000, guid: 026ee88daafe748899bc4eb7335776e9, type: 3}
+  m_dummyPartAmount: 9
+  m_dummyPartMinRarity: 1
+  m_dummyPartMaxRarity: 3

--- a/Assets/Scripts/Data/Store/Chests/GPStoreChestSO.cs
+++ b/Assets/Scripts/Data/Store/Chests/GPStoreChestSO.cs
@@ -38,6 +38,11 @@ public class GPStoreChestSO : ScriptableObject
 
     public void OpenChest()
     {
+        GiveDummyRewards();
+    }
+
+    void GiveDummyRewards()
+    {
         //Suffle part types so they are randombly picked.
         //We'll pick in order so if whe shuffle the lsit they will be random
         //so if the user gets 3 parts they can be of random types (hair, ayes, mouths, wear, gloves, horns, etc)
@@ -47,20 +52,36 @@ public class GPStoreChestSO : ScriptableObject
 
         //Pick random dummy parts
         List<GPDummyPartDesc> dummyRewards = new List<GPDummyPartDesc>();
+        int typeIdx = 0;
         for (int i = 0; i < m_dummyPartAmount; i++)
         {
-            //Pick parts from minimum random rarity to maximum random rairty
-            int randomRarity = Random.Range((int)m_dummyPartMinRarity, (int)m_dummyPartMaxRarity+1);
+            typeIdx = i;
+            if (typeIdx >= randomTypes.Count)
+            {
+                typeIdx = 0;
+            }
+
+            //Pick parts from minimum random rarity to maximum random rarity
+            int randomRarity = Random.Range((int)m_dummyPartMinRarity, (int)m_dummyPartMaxRarity + 1);
 
             //Get list of possible parts that match the random rarity and type.
-            var posibleParts = GPItemsDB.m_instance.GetPartsOfTypeAndRarity(randomTypes[i], (GP_DUMMY_PART_RARITY)randomRarity);
+            var posibleParts = GPItemsDB.m_instance.GetPartsOfTypeAndRarity(randomTypes[typeIdx], (GP_DUMMY_PART_RARITY)randomRarity);
+
+            //if no posible parts found then give any part of any rairty.
+            if (posibleParts.Count == 0)
+            {
+                posibleParts = GPItemsDB.m_instance.GetPartsOfType(randomTypes[typeIdx]);
+            }
 
             //Pick random part from the posible parts.
             int randomPartIdx = Random.Range(0, posibleParts.Count);
             dummyRewards.Add(posibleParts[randomPartIdx]);
         }
 
-        //TODO: Add rewards to player
-
+        foreach (var dummyPart in dummyRewards)
+        {
+            GPPlayerProfile.m_instance.AddDummyPart(dummyPart);
+            Debug.Log("DummyPart Added: " + dummyPart.name);
+        }
     }
 }

--- a/Assets/Scripts/Data/Store/Chests/Golden Chest.asset
+++ b/Assets/Scripts/Data/Store/Chests/Golden Chest.asset
@@ -21,3 +21,6 @@ MonoBehaviour:
   m_gemPrice: 300
   m_specialTag: 2
   m_chestIcon: {fileID: 21300000, guid: 3a63b7ce7a88c4b8682791fbd1eed7e2, type: 3}
+  m_dummyPartAmount: 6
+  m_dummyPartMinRarity: 1
+  m_dummyPartMaxRarity: 2

--- a/Assets/Scripts/Data/Store/Chests/Silver Chest.asset
+++ b/Assets/Scripts/Data/Store/Chests/Silver Chest.asset
@@ -21,3 +21,6 @@ MonoBehaviour:
   m_gemPrice: 150
   m_specialTag: 0
   m_chestIcon: {fileID: 21300000, guid: 5674fbf6acb3541069b44a334bb0c5fc, type: 3}
+  m_dummyPartAmount: 4
+  m_dummyPartMinRarity: 0
+  m_dummyPartMaxRarity: 0

--- a/Assets/Scripts/Data/Store/Chests/WoodenChest.asset
+++ b/Assets/Scripts/Data/Store/Chests/WoodenChest.asset
@@ -21,3 +21,6 @@ MonoBehaviour:
   m_gemPrice: 100
   m_specialTag: 1
   m_chestIcon: {fileID: 21300000, guid: 3443cb2d270604476a4ea0374c523dd7, type: 3}
+  m_dummyPartAmount: 3
+  m_dummyPartMinRarity: 0
+  m_dummyPartMaxRarity: 0

--- a/Assets/Scripts/Menus/GPChestScreen.cs
+++ b/Assets/Scripts/Menus/GPChestScreen.cs
@@ -47,6 +47,7 @@ public class GPChestScreen : GPGUIScreen
         {
             chestCard.OnSuccesfullBuy();
             TanksMP.AudioManager.Play2D(m_buySuccedSFX);
+            OpenChest(chestCard);
         }
         else
         {
@@ -72,11 +73,17 @@ public class GPChestScreen : GPGUIScreen
         {
             chestCard.OnSuccesfullBuy();
             TanksMP.AudioManager.Play2D(m_buySuccedSFX);
+            OpenChest(chestCard);
         }
         else
         {
             TanksMP.AudioManager.Play2D(m_buyErrorSFX);
         }
+    }
+
+    public void OpenChest(GPStoreChestCard chestCard)
+    {
+        chestCard.m_chestDesc.OpenChest();
     }
 
 }

--- a/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
+++ b/Assets/Scripts/Menus/GPCustomizationTabScreen.cs
@@ -11,7 +11,7 @@ public class GPCustomizationTabScreen : GPGUIScreen
 
     [Header("Customization menu references")]
     public Transform m_container; // where parts buttons will be parented
-    private List<GPDummyPartDesc> m_parts;
+    private List<GPDummyPartDesc> m_parts = new List<GPDummyPartDesc>();
     public GPDummyPartBlock m_blockPrefab; // part button prefab
     [HideInInspector]
     public List<GPDummyPartBlock> m_partBlocks = new List<GPDummyPartBlock>(); // store the instanced part buttons
@@ -33,44 +33,8 @@ public class GPCustomizationTabScreen : GPGUIScreen
     // Start is called before the first frame update
     void Start()
     {
-        switch (m_type)
-        {
-            case GP_DUMMY_PART_TYPE.kSkin:
-                m_parts = GPPlayerProfile.m_instance.m_dummySkins;
-                break;
-            case GP_DUMMY_PART_TYPE.kEye:
-                m_parts = GPPlayerProfile.m_instance.m_dummyEyes;
-                break;
-            case GP_DUMMY_PART_TYPE.kMouth:
-                m_parts = GPPlayerProfile.m_instance.m_dummyMouths;
-                break;
-            case GP_DUMMY_PART_TYPE.kHair:
-                m_parts = GPPlayerProfile.m_instance.m_dummyHairs;
-                break;
-            case GP_DUMMY_PART_TYPE.kHorn:
-                m_parts = GPPlayerProfile.m_instance.m_dummyHorns;
-                break;
-            case GP_DUMMY_PART_TYPE.kWear:
-                m_parts = GPPlayerProfile.m_instance.m_dummyWears;
-                break;
-            case GP_DUMMY_PART_TYPE.kGlove:
-                m_parts = GPPlayerProfile.m_instance.m_dummyGloves;
-                break;
-            case GP_DUMMY_PART_TYPE.kTail:
-                m_parts = GPPlayerProfile.m_instance.m_dummyTails;
-                break;
-            default:
-                break;
-        }
-
-        for (int i = 0; i < m_parts.Count; i++)
-        {
-            GPDummyPartBlock newBlock = Instantiate(m_blockPrefab, m_container);
-            newBlock.DisplayPart(m_parts[i]);
-            newBlock.OnSelectedEvent.AddListener(OnBlockSelected);
-            m_partBlocks.Add(newBlock);
-        }
-
+        GPPlayerProfile.m_instance.OnDummyPartsModifiedEvent.AddListener(UpdateAvailableParts);
+        UpdateAvailableParts();
     }
 
     public override void Show()
@@ -287,6 +251,55 @@ public class GPCustomizationTabScreen : GPGUIScreen
         {
             m_selectedBlock = block;
             block.TogglePin(true);
+        }
+    }
+
+    void UpdateAvailableParts()
+    {
+        //m_parts.Clear();
+        switch (m_type)
+        {
+            case GP_DUMMY_PART_TYPE.kSkin:
+                m_parts = GPPlayerProfile.m_instance.m_dummySkins;
+                break;
+            case GP_DUMMY_PART_TYPE.kEye:
+                m_parts = GPPlayerProfile.m_instance.m_dummyEyes;
+                break;
+            case GP_DUMMY_PART_TYPE.kMouth:
+                m_parts = GPPlayerProfile.m_instance.m_dummyMouths;
+                break;
+            case GP_DUMMY_PART_TYPE.kHair:
+                m_parts = GPPlayerProfile.m_instance.m_dummyHairs;
+                break;
+            case GP_DUMMY_PART_TYPE.kHorn:
+                m_parts = GPPlayerProfile.m_instance.m_dummyHorns;
+                break;
+            case GP_DUMMY_PART_TYPE.kWear:
+                m_parts = GPPlayerProfile.m_instance.m_dummyWears;
+                break;
+            case GP_DUMMY_PART_TYPE.kGlove:
+                m_parts = GPPlayerProfile.m_instance.m_dummyGloves;
+                break;
+            case GP_DUMMY_PART_TYPE.kTail:
+                m_parts = GPPlayerProfile.m_instance.m_dummyTails;
+                break;
+            default:
+                break;
+        }
+
+        //clear old blocks
+        foreach (var item in m_partBlocks)
+        {
+            Destroy(item.gameObject);
+        }
+
+        m_partBlocks.Clear();
+        for (int i = 0; i < m_parts.Count; i++)
+        {
+            GPDummyPartBlock newBlock = Instantiate(m_blockPrefab, m_container);
+            newBlock.DisplayPart(m_parts[i]);
+            newBlock.OnSelectedEvent.AddListener(OnBlockSelected);
+            m_partBlocks.Add(newBlock);
         }
     }
 }

--- a/Assets/Scripts/Menus/GPRollScreen.cs
+++ b/Assets/Scripts/Menus/GPRollScreen.cs
@@ -33,6 +33,10 @@ public class GPRollScreen : GPGUIScreen
     public List<GPWheelPrize> m_prizes;
     WeightedList<string> m_weightedList = new();
 
+    [Header("Prize chest refrences")]
+    public GPStoreChestSO m_woodChest;
+    public GPStoreChestSO m_goldenChest;
+
     [Header("Animation settings")]
     public int m_numberCirclestoRotate = 5;
     public float m_rotateTime = 3.0f;
@@ -145,8 +149,16 @@ public class GPRollScreen : GPGUIScreen
                 GPPlayerProfile.m_instance.AddEnergy(prize.m_prizeAmount);
                 break;
             case GP_PRIZE_TYPE.kWoodenChest:
+                for (int i = 0; i < prize.m_prizeAmount; i++)
+                {
+                    m_woodChest.OpenChest();
+                }
                 break;
             case GP_PRIZE_TYPE.kGoldenChest:
+                for (int i = 0; i < prize.m_prizeAmount; i++)
+                {
+                    m_goldenChest.OpenChest();
+                }
                 break;
             default:
                 break;

--- a/Assets/Scripts/Systems/GPItemsDB.cs
+++ b/Assets/Scripts/Systems/GPItemsDB.cs
@@ -91,4 +91,17 @@ public class GPItemsDB : MonoBehaviour
         }
         return parts;
     }
+
+    public List<GPDummyPartDesc> GetPartsOfType(GP_DUMMY_PART_TYPE type)
+    {
+        List<GPDummyPartDesc> parts = new List<GPDummyPartDesc>();
+        foreach (KeyValuePair<string, GPDummyPartDesc> entry in m_dummyPartsMap)
+        {
+            if (entry.Value.m_type == type)
+            {
+                parts.Add(entry.Value);
+            }
+        }
+        return parts;
+    }
 }

--- a/Assets/Scripts/Systems/GPPlayerProfile.cs
+++ b/Assets/Scripts/Systems/GPPlayerProfile.cs
@@ -27,6 +27,7 @@ public class GPPlayerProfile : MonoBehaviour
     public List<GPDummyPartDesc> m_dummyWears;
     public List<GPDummyPartDesc> m_dummyGloves;
     public List<GPDummyPartDesc> m_dummyTails;
+    public UnityEvent OnDummyPartsModifiedEvent; // called when player gets new dummy part
 
     //public List<GPDummyData> m_dummySlots = new List<GPDummyData>();
     //public int m_currDummySlotIdx = 0;
@@ -83,6 +84,68 @@ public class GPPlayerProfile : MonoBehaviour
         if (OnEnergyModifiedEvent != null)
         {
             OnEnergyModifiedEvent.Invoke();
+        }
+    }
+
+    public void AddDummyPart(GPDummyPartDesc dummyPart)
+    {
+        switch (dummyPart.m_type)
+        {
+            case GP_DUMMY_PART_TYPE.kSkin:
+                if (!m_dummySkins.Contains(dummyPart))
+                {
+                    m_dummySkins.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kEye:
+                if (!m_dummyEyes.Contains(dummyPart))
+                {
+                    m_dummyEyes.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kMouth:
+                if (!m_dummyMouths.Contains(dummyPart))
+                {
+                    m_dummyMouths.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kHair:
+                if (!m_dummyHairs.Contains(dummyPart))
+                {
+                    m_dummyHairs.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kHorn:
+                if (!m_dummyHorns.Contains(dummyPart))
+                {
+                    m_dummyHorns.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kWear:
+                if (!m_dummyWears.Contains(dummyPart))
+                {
+                    m_dummyWears.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kGlove:
+                if (!m_dummyGloves.Contains(dummyPart))
+                {
+                    m_dummyGloves.Add(dummyPart);
+                }
+                break;
+            case GP_DUMMY_PART_TYPE.kTail:
+                if (!m_dummyTails.Contains(dummyPart))
+                {
+                    m_dummyTails.Add(dummyPart);
+                }
+                break;
+            default:
+                break;
+        }
+
+        if (OnDummyPartsModifiedEvent != null)
+        {
+            OnDummyPartsModifiedEvent.Invoke();
         }
     }
 


### PR DESCRIPTION
-Method for giving dummy parts to player added.
-Setted the dummy reward settings of all chest scriptable objects.
-Dummy parts rewards are now given to the player when he buys a chest.
-Now the available dummy parts of the customization screen updates when the player gets a new dummy part from chests.
-Now the player initialy only has one skin color and default eyes for his dummy.
-Spinning wheel now also opens chests if the player lands in that reward.