### PR TITLE
Dev Mick

### DIFF
--- a/Assets/Prefabs/UI/DummyPartUIBlock.prefab
+++ b/Assets/Prefabs/UI/DummyPartUIBlock.prefab
@@ -324,7 +324,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5816341177092805439
 RectTransform:
   m_ObjectHideFlags: 0
@@ -343,7 +343,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -70.469, y: 70.469}
+  m_AnchoredPosition: {x: -44, y: -64}
   m_SizeDelta: {x: 35, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5816341177092805437

--- a/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
+++ b/Assets/Scripts/Data/Dummies/Head/GPHair 6.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: e86e3273-2bfa-43e5-b7f3-753ba726f72c
   m_type: 3
-  m_rarity: 1
+  m_rarity: 2
   m_gameObjectName: Hair06
   m_displayIcon: {fileID: 21300000, guid: 3e5520e090310e84fb6a6720fec2f842, type: 3}
   m_material: {fileID: 0}

--- a/Assets/Scripts/Data/Dummies/Horns/GPEar01.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPEar01.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: f329d36a-e9d8-4ff0-a630-48614fd6f06e
   m_type: 4
-  m_rarity: 3
+  m_rarity: 1
   m_gameObjectName: Ear01
   m_displayIcon: {fileID: 21300000, guid: fecba2c73c6108d409a8adf77a0725cb, type: 3}
   m_material: {fileID: 2100000, guid: 3b606c9cb6c05184ab108264eeaad5b0, type: 2}

--- a/Assets/Scripts/Data/Dummies/Horns/GPEar03.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPEar03.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: f329d36a-e9d8-4ff0-a630-48614fd6f06e
   m_type: 4
-  m_rarity: 2
+  m_rarity: 3
   m_gameObjectName: Ear03
   m_displayIcon: {fileID: 21300000, guid: cd6c5bcba81e16a41b73d4673e3d6552, type: 3}
   m_material: {fileID: 2100000, guid: 563b869b2c9768c4b987831907fe45f6, type: 2}

--- a/Assets/Scripts/Data/Dummies/Horns/GPEar05.asset
+++ b/Assets/Scripts/Data/Dummies/Horns/GPEar05.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: f329d36a-e9d8-4ff0-a630-48614fd6f06e
   m_type: 4
-  m_rarity: 2
+  m_rarity: 3
   m_gameObjectName: Ear05
   m_displayIcon: {fileID: 21300000, guid: f79e6a6221b28f74dbaba1b11dc00ba5, type: 3}
   m_material: {fileID: 2100000, guid: d86c73d4d217b3e4ca771f4525971d1d, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 1.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 1.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: f7a54475-40cd-4b5e-bb74-fe103b53eec4
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 284c3ea7989e0734cabf03d161145baf, type: 3}
   m_material: {fileID: 2100000, guid: 006d176b5b1c0ba4584180f26bc954e1, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 10.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 10.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 94451fd1-9c7a-4b23-acbf-fb603d3ce41b
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 52033aeef281c4e4aa498b42e4004bbd, type: 3}
   m_material: {fileID: 2100000, guid: ad9e8546f02988f4d9fd43a0d219a4af, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 11.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: eaa993f7-29f1-41ad-9b22-8f71b07ea94b
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: b0de84002d748dd4996d28ffdf6d2970, type: 3}
   m_material: {fileID: 2100000, guid: 0dd4b9cfb3203b54d8563bdb2fafbc95, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 12.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 9f42a574-5bb8-4f0e-ae74-70970ac83d63
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 5674f42c47dd27f41ace6cb6c8502bb8, type: 3}
   m_material: {fileID: 2100000, guid: 4929e78ca37223c45b5e0e804b7ecef3, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 13.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: fc4b5628-6c70-4a39-9c63-ec130f0d4a9f
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 911ce93e04edd944f88615f6a66f3a66, type: 3}
   m_material: {fileID: 2100000, guid: dad2247653b10134eaccb110018e477c, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 14.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 164192e5-582f-4e6c-a036-df3cee671aea
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 3047e50ce70045f4686c5fcc56406404, type: 3}
   m_material: {fileID: 2100000, guid: c94e94c098e1b3b419981af72a4126ba, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 15.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: be15d0e6-1f62-4f45-9460-96ecefd49646
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: bcd053989cc56de4a8655adb0bcb2d87, type: 3}
   m_material: {fileID: 2100000, guid: fbc354bc6effe4543b4757a7d1f1fea3, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 16.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: cb0ce233-78ea-4a81-b56d-7f776c90711e
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: f34179bffb711a24481d67d88e302716, type: 3}
   m_material: {fileID: 2100000, guid: 0b4d48e56a481e94dad6cf08a9d96edd, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 17.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 71b79eb1-39f2-438d-b44f-8a88527d6309
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: e9d353d0b95fd694b9456995f94266de, type: 3}
   m_material: {fileID: 2100000, guid: 0450740ab1638ff4e83e941623776159, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 18.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 73915e1e-6499-4866-a03a-b60c3e1dc76b
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: f1bf8a904f5e6164b95712bf0145424e, type: 3}
   m_material: {fileID: 2100000, guid: 27b813325e6379140bc12bb0d446603c, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 19.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: e55092a0-4248-4d48-8da5-7d26cbc4407c
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 76d8432596ee9714a88e6dade50932b2, type: 3}
   m_material: {fileID: 2100000, guid: e79508f9ca67dd34494ae7820325bd81, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 2.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 2.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: c8a2d0ab-0fd5-4506-bf57-17c8f3b8972a
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 0e4d78155d523c841998d8d838c3683a, type: 3}
   m_material: {fileID: 2100000, guid: 7673349d55d9b5541a4277a315b2d077, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 3.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 3.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 5d70f020-dfcf-4f90-8892-c2c12c725ad3
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 23dc4ed3f464eee4f9dd96bace6675d5, type: 3}
   m_material: {fileID: 2100000, guid: 70973542d9b4b094ea709dae3eeff935, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 4.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 4.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 063e65f8-c68d-4b3f-9ff6-474e9323d60d
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: af9d085bca4852f4481ea2b868ef5bb8, type: 3}
   m_material: {fileID: 2100000, guid: c08ade5cc12b0be48ac31474e428e982, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 5.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 5.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 381a3eae-6b56-4c8c-bb83-853169d7570e
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: b2ed76677f98a6848a5f4a31fded32a0, type: 3}
   m_material: {fileID: 2100000, guid: 1d46d1831c17a3049be93f75a7cf3061, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 6.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 6.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 4bc6a75d-76c3-4207-91c7-959a459ea439
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 401254930881d3e46963479f73fa3181, type: 3}
   m_material: {fileID: 2100000, guid: 8ac7bcd1cb9b6cb4c86296d9aec67f3f, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 7.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 7.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 97700e6d-bd11-45a2-b638-fb82dee6f538
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: d50a22f6de907924d83d21b165e36507, type: 3}
   m_material: {fileID: 2100000, guid: def6cbd7bf5c67a41b66c98080ccd014, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 8.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 8.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 4e0b7f92-9c37-4d3c-9a93-979232c9cdcf
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: e104168c0f83a564c9d0610d3b60b0f9, type: 3}
   m_material: {fileID: 2100000, guid: 2c12c79afc549d741af5c7a47f2603a4, type: 2}

--- a/Assets/Scripts/Data/Dummies/Skin/GPSkin 9.asset
+++ b/Assets/Scripts/Data/Dummies/Skin/GPSkin 9.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: 24af5478-cbd6-4b1e-900b-294a0883ba3b
   m_type: 0
-  m_rarity: 0
+  m_rarity: 1
   m_gameObjectName: MainBody01
   m_displayIcon: {fileID: 21300000, guid: 2515e7741a8dc4848a783f3c63449230, type: 3}
   m_material: {fileID: 2100000, guid: ba56c1dc340a2ad40a36924cf2b743c2, type: 2}

--- a/Assets/Scripts/Data/Dummies/Wear/GPWear 3.asset
+++ b/Assets/Scripts/Data/Dummies/Wear/GPWear 3.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   m_type: 5
   m_rarity: 3
   m_gameObjectName: Bodypart03
-  m_displayIcon: {fileID: 21300000, guid: c5efe8c28c7a5c447a77c36f2bdee61a, type: 3}
+  m_displayIcon: {fileID: 21300000, guid: 42ecfe742f2610243a9296def3d6b385, type: 3}
   m_material: {fileID: 2100000, guid: fa3871c3befb6c046bc2d562ce5bbc6e, type: 2}

--- a/Assets/Scripts/Data/Store/Chests/GPStoreChestSO.cs
+++ b/Assets/Scripts/Data/Store/Chests/GPStoreChestSO.cs
@@ -91,6 +91,12 @@ public class GPStoreChestSO : ScriptableObject
             //Get list of possible parts that match the random rarity and type.
             var posibleParts = GPItemsDB.m_instance.GetPartsOfTypeAndRarity(randomTypes[typeIdx], (GP_DUMMY_PART_RARITY)randomRarity);
 
+            //if no posible parts found then give any part of the specified rairty.
+            if (posibleParts.Count == 0)
+            {
+                posibleParts = GPItemsDB.m_instance.GetPartsOfRarity((GP_DUMMY_PART_RARITY)randomRarity);
+            }
+
             //if no posible parts found then give any part of any rairty.
             if (posibleParts.Count == 0)
             {

--- a/Assets/Scripts/Menus/GPLevelUpScreen.cs
+++ b/Assets/Scripts/Menus/GPLevelUpScreen.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 public class GPLevelUpScreen : GPGUIScreen
 {
@@ -16,6 +17,9 @@ public class GPLevelUpScreen : GPGUIScreen
     [Header("Audio Settings")]
     public AudioClip m_showSFX;
     public AudioClip m_continueClickedSFX;
+
+    [Header("OTher references Settings")]
+    public TextMeshProUGUI m_levelText;
 
     [Header("Misc.")]
     [SerializeField]
@@ -33,6 +37,7 @@ public class GPLevelUpScreen : GPGUIScreen
         m_punchTween.PunchEffect();
         GiveRewards();
         TanksMP.AudioManager.Play2D(m_showSFX);
+        m_levelText.text = APIManager.Instance.PlayerData.Level.ToString();
     }
 
     public override void Hide()

--- a/Assets/Scripts/Menus/GPProfileWindow.cs
+++ b/Assets/Scripts/Menus/GPProfileWindow.cs
@@ -24,6 +24,10 @@ public class GPProfileWindow : GPGWindowUI
     public TextMeshProUGUI m_KDRatioText;
     public TextMeshProUGUI m_winRateText;
 
+    [Header("Exp")]
+    public Image m_expFill;
+    public TextMeshProUGUI m_expText;
+
     [Header("Audio settings")]
     public AudioClip m_equipSFX;
 
@@ -47,6 +51,7 @@ public class GPProfileWindow : GPGWindowUI
         }
 
         UpdateLevelText();
+        UpdateExpUI();
     }
 
     void Update()
@@ -70,6 +75,7 @@ public class GPProfileWindow : GPGWindowUI
         }
 
         UpdateLevelText();
+        UpdateExpUI();
     }
 
     public override void Hide()
@@ -132,6 +138,13 @@ public class GPProfileWindow : GPGWindowUI
         {
             levelText.text = APIManager.Instance.PlayerData.Level.ToString();
         }
+    }
+
+    void UpdateExpUI()
+    {
+        int nextLevelEXP = 100; // TODO: Calcualte this from another system.
+        m_expFill.fillAmount = (float)APIManager.Instance.PlayerData.Exp / (float)nextLevelEXP;
+        m_expText.text = APIManager.Instance.PlayerData.Exp.ToString() + "/" + nextLevelEXP.ToString() + " XP";
     }
 
 }

--- a/Assets/Scripts/Systems/GPItemsDB.cs
+++ b/Assets/Scripts/Systems/GPItemsDB.cs
@@ -126,4 +126,17 @@ public class GPItemsDB : MonoBehaviour
         }
         return parts;
     }
+
+    public List<GPDummyPartDesc> GetPartsOfRarity(GP_DUMMY_PART_RARITY rarity)
+    {
+        List<GPDummyPartDesc> parts = new List<GPDummyPartDesc>();
+        foreach (KeyValuePair<string, GPDummyPartDesc> entry in m_dummyPartsMap)
+        {
+            if (entry.Value.m_rarity == rarity)
+            {
+                parts.Add(entry.Value);
+            }
+        }
+        return parts;
+    }
 }


### PR DESCRIPTION
-Level up screen now displays the level number from the PlayerData of the API manager.
-Bug fixed where the wear tab of the customization screen didn't show the props.
-Bug fixed where some dummy parts didn't have a sprite assigned.
-XP bar now displays the current XP value given by the player data of the API manager.
-Level up dev cheat button now doesn't render on top of other menus.
-Dummy part UI block's pins relocated.
-Modified the chest reward algorithm for chosing the dummy parts, now if there aren't engough parts of the specified tier and type then it prioritizes searching one of the specified tier even if the type is repeated.
-Setted the tier of many dummy parts that didn't match their new sprite tier.