### PR TITLE
dev mick

### DIFF
--- a/Assets/Prefabs/UI/FriendSlotUI.prefab
+++ b/Assets/Prefabs/UI/FriendSlotUI.prefab
@@ -1724,9 +1724,9 @@ MonoBehaviour:
   m_statusIcon: {fileID: 5391126101812049882}
   m_offlineSprite: {fileID: 21300000, guid: b2b2b5de96fed40d2898dd15c17892e6, type: 3}
   m_onlineSprite: {fileID: 21300000, guid: 4ad15db1aebb749f5b1846fbbfa25de7, type: 3}
-  m_addButton: {fileID: 0}
-  m_chatButton: {fileID: 0}
-  m_blockButton: {fileID: 0}
+  m_addButton: {fileID: 2336857347621304783}
+  m_chatButton: {fileID: 1254704006904994089}
+  m_blockButton: {fileID: 6093638423634926656}
   onAddButtonClickedEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/Menus/GPChestOpeningLogic.cs
+++ b/Assets/Scripts/Menus/GPChestOpeningLogic.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GPChestOpeningLogic : MonoBehaviour
+{
+    [Header("Audio settings")]
+    public AudioClip m_chestOpenSFX;
+
+    [Header("Chest Rewards Settings")]
+    public GPChestRewardWindow m_rewardWindow;
+    public GPGUIScreen m_rewardScreen;
+
+    /// <summary>
+    /// Displays the chest opening screen and gives the content to the player.
+    /// </summary>
+    /// <param name="chestDesc"></param>
+    public void OpenChest(GPStoreChestSO chestDesc)
+    {
+        GPGivenRewards rewards = chestDesc.OpenChest();
+        m_rewardScreen.Show();
+        m_rewardWindow.Show();
+        m_rewardWindow.ClearContent();
+        m_rewardWindow.DisplayChestImage(chestDesc);
+        m_rewardWindow.DisplayCrewRewards(rewards.m_ships);
+        m_rewardWindow.DisplayIconRewards(rewards.m_profileIcons);
+        m_rewardWindow.DisplayDummyRewards(rewards.m_dummyParts);
+        StartCoroutine(CloseRewardWindow()); // for now close reward window after 3 seconds
+    }
+
+    IEnumerator CloseRewardWindow()
+    {
+        yield return new WaitForSeconds(3.0f);
+        m_rewardScreen.Hide();
+        m_rewardWindow.Hide();
+    }
+
+    /// <summary>
+    /// Opens all given chests in sequence.
+    /// </summary>
+    /// <param name="chests"></param>
+    public void OpenChestsInSequence(List<GPStoreChestSO> chests)
+    {
+        StartCoroutine(IEOpenChestsInSecuence(chests));
+    }
+
+    IEnumerator IEOpenChestsInSecuence(List<GPStoreChestSO> chests)
+    {
+        for (int i = 0; i < chests.Count; i++)
+        {
+            OpenChest(chests[i]);
+            yield return new WaitForSeconds(3.0f);
+            if (i < chests.Count - 1) // so the last one doesn't play a sound at the end
+            {
+                TanksMP.AudioManager.Play2D(m_chestOpenSFX);
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/Menus/GPChestOpeningLogic.cs.meta
+++ b/Assets/Scripts/Menus/GPChestOpeningLogic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03b9d7d4de81677429c61313ca416676
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menus/GPFriendsTaps.cs
+++ b/Assets/Scripts/Menus/GPFriendsTaps.cs
@@ -20,7 +20,7 @@ public class GPFriendsTaps : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        m_friendCounter.text = GPPlayerProfile.m_instance.m_friends.Count.ToString();
+        SetFriendCounterText(GPPlayerProfile.m_instance.m_friends.Count);
     }
 
     public void AddFriendToTeam()
@@ -28,6 +28,10 @@ public class GPFriendsTaps : MonoBehaviour
         //TODO: Handle joining team.
     }
 
+    /// <summary>
+    /// Displays the friend number on the UI.
+    /// </summary>
+    /// <param name="friendCount"></param>
     public void SetFriendCounterText(int friendCount)
     {
         m_friendCounter.text = friendCount.ToString();
@@ -43,6 +47,10 @@ public class GPFriendsTaps : MonoBehaviour
         LeanTween.move(m_tabFocusImage.gameObject, targetTransform.position, 0.3f).setEaseSpring();
     }
 
+    /// <summary>
+    /// Play SFX and moves the focus sprite to the clicked button.
+    /// </summary>
+    /// <param name="buttonIdx"></param>
     public void OnButtonClicked(int buttonIdx)
     {
         MoveTapFocus(m_buttons[buttonIdx].transform);

--- a/Assets/Scripts/Menus/GPLevelUpScreen.cs
+++ b/Assets/Scripts/Menus/GPLevelUpScreen.cs
@@ -34,9 +34,14 @@ public class GPLevelUpScreen : GPGUIScreen
     public override void Show()
     {
         base.Show();
-        m_punchTween.PunchEffect();
+
         GiveRewards();
+
+        //Play effects
+        m_punchTween.PunchEffect();
         TanksMP.AudioManager.Play2D(m_showSFX);
+
+        //Display the new current level on the UI
         m_levelText.text = APIManager.Instance.PlayerData.Level.ToString();
 
         //clear old rewards
@@ -58,12 +63,18 @@ public class GPLevelUpScreen : GPGUIScreen
         base.Hide();
     }
 
+    /// <summary>
+    /// Hides the screen and plays a SFX.
+    /// </summary>
     public void ContinueButtonPressed()
     {
         Hide();
         TanksMP.AudioManager.Play2D(m_continueClickedSFX);
     }
 
+    /// <summary>
+    /// Gives all the level up rewards to the player.
+    /// </summary>
     public async void GiveRewards()
     {
         m_LoadIndicator.SetActive(true);

--- a/Assets/Scripts/Menus/GPProfileWindow.cs
+++ b/Assets/Scripts/Menus/GPProfileWindow.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using TanksMP;
+using Photon.Pun;
 
 public class GPProfileWindow : GPGWindowUI
 {
@@ -35,6 +36,7 @@ public class GPProfileWindow : GPGWindowUI
     {
         m_closeButton.onClick.AddListener(Hide);
 
+        //instantiate the profile icon UI blocks for all existing icons
         for (int i = 0; i < GPItemsDB.m_instance.m_profileIcons.Count; i++)
         {
             GPProfileIconBlock block = Instantiate(m_profileIconBlockPrefab, m_iconsHolder);
@@ -43,12 +45,10 @@ public class GPProfileWindow : GPGWindowUI
             m_spawnedBlocks.Add(block);
         }
 
-        // set up stats
-        if (PlayerPrefs.HasKey(PrefsKeys.playerName))
-        {
-            m_nameText.text = PlayerPrefs.GetString(PrefsKeys.playerName);
-        }
+        //Display the name from the API
+        m_nameText.text = APIManager.Instance.PlayerData.Name;
 
+        //Display the current level text and EXP amount in the UI
         UpdateLevelText();
         UpdateExpUI();
     }
@@ -65,6 +65,7 @@ public class GPProfileWindow : GPGWindowUI
 
         foreach (var block in m_spawnedBlocks)
         {
+            //Display as locked or unlocked
             block.ToggleLocked(!GPPlayerProfile.m_instance.m_profileIcons.Contains(block.m_profileIconDesc));
 
             if (block.m_profileIconDesc.m_sprite == m_homeUserMiniature.m_assignedProfileIconSprite)
@@ -73,6 +74,7 @@ public class GPProfileWindow : GPGWindowUI
             }
         }
 
+        //Display the current level text and EXP amount in the UI
         UpdateLevelText();
         UpdateExpUI();
     }
@@ -83,6 +85,10 @@ public class GPProfileWindow : GPGWindowUI
         TanksMP.AudioManager.Play2D(m_hideSound);
     }
 
+    /// <summary>
+    /// If the clicked icon is unlocked then it is displayed on the preview profile icon.
+    /// </summary>
+    /// <param name="block"></param>
     void OnClickedIcon(GPProfileIconBlock block)
     {
         if (block.m_isLocked)
@@ -107,6 +113,10 @@ public class GPProfileWindow : GPGWindowUI
         TanksMP.AudioManager.Play2D(m_equipSFX);
     }
 
+    /// <summary>
+    /// Displays the player stats (wins, loss, draws, etc) on the profile window UI.
+    /// </summary>
+    /// <param name="data"></param>
     public void WriteStats(StatsData data)
     {
         m_winsText.text = data.Wins.ToString();
@@ -126,12 +136,18 @@ public class GPProfileWindow : GPGWindowUI
         m_winRateText.text = winRate.ToString() + "%";
     }
 
+    /// <summary>
+    /// Upates the displayed player level.
+    /// </summary>
     void UpdateLevelText()
     {
         m_homeUserMiniature.SetLevel(APIManager.Instance.PlayerData.Level);
         m_profileWindowUserMiniature.SetLevel(APIManager.Instance.PlayerData.Level);
     }
 
+    /// <summary>
+    /// Upates the displayed player EXP on the fill bar and text.
+    /// </summary>
     void UpdateExpUI()
     {
         int nextLevelEXP = 100; // TODO: Calcualte this from another system.

--- a/Assets/Scripts/Menus/GPWaitingRoom.cs
+++ b/Assets/Scripts/Menus/GPWaitingRoom.cs
@@ -67,6 +67,7 @@ public class GPWaitingRoom : MonoBehaviourPunCallbacks, IPunObservable
     bool m_levelLoadedCalled = false;
 
     [Header("Ready")]
+    public Button m_weighAnchorButton;
     List<string> m_playersReady = new List<string>();
     bool m_weighAnchorAlreadyPressed = false;
 
@@ -276,6 +277,7 @@ public class GPWaitingRoom : MonoBehaviourPunCallbacks, IPunObservable
         m_crewSelectionWindow.SetActive(false);
         m_photonView.RPC("RPCSetReady", RpcTarget.AllBuffered, PhotonNetwork.LocalPlayer.UserId);
         TanksMP.AudioManager.Play2D(m_weighAnchorClickedSFX);
+        m_weighAnchorButton.interactable = false;
     }
 
     public void OnHomeButtonPressed()

--- a/Assets/Scripts/Menus/GPWeeklyRewardScreen.cs
+++ b/Assets/Scripts/Menus/GPWeeklyRewardScreen.cs
@@ -13,7 +13,7 @@ public class GPWeeklyRewardScreen : GPGUIScreen
         public int m_amount = 0;
     }
 
-
+    [Header("Reward settings")]
     public TextMeshProUGUI m_rewardCounterText;
     public List<GPWeeklyRewardBlock> m_rewardBlocks;
     [Tooltip("Prizes to give each day in order. Only the first 7 will be used (one per day).")]
@@ -26,16 +26,13 @@ public class GPWeeklyRewardScreen : GPGUIScreen
     [Header("Audio settings")]
     public AudioClip m_showScreenSFX;
     public AudioClip m_claimSFX;
-    public AudioClip m_chestOpenSFX;
 
     [Header("Misc.")]
     [SerializeField]
     private GameObject m_LoadIndicator;
 
     [Header("Chest Rewards Settings")]
-    public GPChestRewardWindow m_rewardWindow;
-    public GPGUIScreen m_rewardScreen;
-    
+    public GPChestOpeningLogic m_chestOpeningLogic;
 
     // Start is called before the first frame update
     void Start()
@@ -57,6 +54,9 @@ public class GPWeeklyRewardScreen : GPGUIScreen
         base.Hide();
     }
 
+    /// <summary>
+    /// Gives the rewards to the player, play effects and updates the claimed reward number.
+    /// </summary>
     public void ClaimReward()
     {
         GivePrize(m_rewards[m_currClaimedIdx]);
@@ -66,6 +66,9 @@ public class GPWeeklyRewardScreen : GPGUIScreen
         Hide();
     }
 
+    /// <summary>
+    /// Resets the current reward to claim to be the first one.
+    /// </summary>
     public void ResetWeekProgress()
     {
         m_currClaimedIdx = 0;
@@ -73,8 +76,9 @@ public class GPWeeklyRewardScreen : GPGUIScreen
     }
 
     /// <summary>
-    /// Displays the reward sprites, eneables check marks on the claimed ones, disiplays the number of claimed rewards
-    /// and enables the focus sprite on the current reward block.
+    /// Displays the reward sprites, eneables check marks on the claimed ones,
+    /// displays the number of claimed rewards and enables the focus sprite on
+    /// the current reward block.
     /// </summary>
     void UpdateDisplayedData()
     {
@@ -90,6 +94,10 @@ public class GPWeeklyRewardScreen : GPGUIScreen
         }
     }
 
+    /// <summary>
+    /// Gives the given weekly reward to the player.
+    /// </summary>
+    /// <param name="reward"></param>
     public async void GivePrize(WeeklyReward reward)
     {
         switch (reward.m_rewardSO.m_type)
@@ -114,7 +122,7 @@ public class GPWeeklyRewardScreen : GPGUIScreen
                     {
                         chests.Add(GPItemsDB.m_instance.m_woodenChest);
                     }
-                    OpenChestsInSequence(chests);
+                    m_chestOpeningLogic.OpenChestsInSequence(chests);
                     break;
                 }
             case GP_PRIZE_TYPE.kSilverChest:
@@ -124,7 +132,7 @@ public class GPWeeklyRewardScreen : GPGUIScreen
                     {
                         chests.Add(GPItemsDB.m_instance.m_silverChest);
                     }
-                    OpenChestsInSequence(chests);
+                    m_chestOpeningLogic.OpenChestsInSequence(chests);
                     break;
                 }
             case GP_PRIZE_TYPE.kGoldenChest:
@@ -134,7 +142,7 @@ public class GPWeeklyRewardScreen : GPGUIScreen
                     {
                         chests.Add(GPItemsDB.m_instance.m_goldenChest);
                     }
-                    OpenChestsInSequence(chests);
+                    m_chestOpeningLogic.OpenChestsInSequence(chests);
                     break;
                 }
             case GP_PRIZE_TYPE.kCrystalChest:
@@ -144,50 +152,12 @@ public class GPWeeklyRewardScreen : GPGUIScreen
                     {
                         chests.Add(GPItemsDB.m_instance.m_crystalChest);
                     }
-                    OpenChestsInSequence(chests);
+                    m_chestOpeningLogic.OpenChestsInSequence(chests);
                     break;
                 }
             default:
                 break;
         }
-    }
-
-    public void OpenChestsInSequence(List<GPStoreChestSO> chests)
-    {
-        StartCoroutine(IEOpenChestsInSecuence(chests));
-    }
-
-    IEnumerator IEOpenChestsInSecuence(List<GPStoreChestSO> chests)
-    {
-        for (int i = 0; i < chests.Count; i++)
-        {
-            OpenChest(chests[i]);
-            yield return new WaitForSeconds(3.0f);
-            if (i < chests.Count - 1) // so the last one doesn't play a sound at the end
-            {
-                TanksMP.AudioManager.Play2D(m_chestOpenSFX);
-            }
-        }
-    }
-
-    public void OpenChest(GPStoreChestSO chestDesc)
-    {
-        GPGivenRewards rewards = chestDesc.OpenChest();
-        m_rewardScreen.Show();
-        m_rewardWindow.Show();
-        m_rewardWindow.ClearContent();
-        m_rewardWindow.DisplayChestImage(chestDesc);
-        m_rewardWindow.DisplayCrewRewards(rewards.m_ships);
-        m_rewardWindow.DisplayIconRewards(rewards.m_profileIcons);
-        m_rewardWindow.DisplayDummyRewards(rewards.m_dummyParts);
-        StartCoroutine(CloseRewardWindow()); // for now close reward window after 3 seconds
-    }
-
-    IEnumerator CloseRewardWindow()
-    {
-        yield return new WaitForSeconds(3.0f);
-        m_rewardScreen.Hide();
-        m_rewardWindow.Hide();
     }
 
 }

--- a/Assets/Scripts/Systems/GPPlayerProfile.cs
+++ b/Assets/Scripts/Systems/GPPlayerProfile.cs
@@ -5,19 +5,12 @@ using UnityEngine.Events;
 
 public class GPPlayerProfile : MonoBehaviour
 {
-    /*[Header("Currency settings")]
-    public int m_gems;
-    public UnityEvent OnGemsModifiedEvent;
-    public int m_gold;
-    public UnityEvent OnGoldModifiedEvent;*/
-
     [Header("Energy settings")]
     public int m_energy;
     public int m_maxEnergy = 10;
     public UnityEvent OnEnergyModifiedEvent;
 
     [Header("Owned items settings")]
-    public List<GPStoreChestSO> m_chests;
     public List<GPShipDesc> m_ships;
     public List<GPProfileIconSO> m_profileIcons;
     public List<GPDummyPartDesc> m_dummySkins;
@@ -29,9 +22,6 @@ public class GPPlayerProfile : MonoBehaviour
     public List<GPDummyPartDesc> m_dummyGloves;
     public List<GPDummyPartDesc> m_dummyTails;
     public UnityEvent OnDummyPartsModifiedEvent; // called when player gets new dummy part
-
-    //public List<GPDummyData> m_dummySlots = new List<GPDummyData>();
-    //public int m_currDummySlotIdx = 0;
 
     [Header("Social Settings")]
     public List<GPFriend> m_friends = new List<GPFriend>(); // still not sure how the API will manage this but i'll use this data in the meantime for the UI building.
@@ -81,6 +71,10 @@ public class GPPlayerProfile : MonoBehaviour
         return true;
     }
 
+    /// <summary>
+    /// Called whenever the energy is modified.
+    /// Invokes OnEnergyModifiedEvent.
+    /// </summary>
     void OnEnergyModified()
     {
         m_energy = Mathf.Clamp(m_energy, 0, m_maxEnergy);
@@ -91,6 +85,10 @@ public class GPPlayerProfile : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Adds a dummy part to the owned parts by the user locally.
+    /// </summary>
+    /// <param name="dummyPart"></param>
     public void AddDummyPart(GPDummyPartDesc dummyPart)
     {
         switch (dummyPart.m_type)
@@ -153,6 +151,10 @@ public class GPPlayerProfile : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Adds a ship to the owned ships by the user locally.
+    /// </summary>
+    /// <param name="shipDesc"></param>
     public void AddShip(GPShipDesc shipDesc)
     {
         if (!m_ships.Contains(shipDesc))
@@ -161,6 +163,10 @@ public class GPPlayerProfile : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Adds a profile icon to the owned parts by the user locally.
+    /// </summary>
+    /// <param name="iconDesc"></param>
     public void AddProfileIcon(GPProfileIconSO iconDesc)
     {
         if (!m_profileIcons.Contains(iconDesc))
@@ -169,74 +175,4 @@ public class GPPlayerProfile : MonoBehaviour
         }
     }
 
-    /*public void AddGold(int amount)
-    {
-        //TODO: maybe we should do an api call here for modifying the amount on the API and then reading back the value.
-        m_gold += amount;
-        OnGoldModified();
-    }*/
-
-    /// <summary>
-    /// Tries to spend gold if it has enough.
-    /// Returns true if user had enough gold to spend, false otherwise.
-    /// </summary>
-    /// <param name="amount"></param>
-    /// <returns></returns>
-    /*public bool TrySpendGold(int amount)
-    {
-        if (m_gold < amount)
-        {
-            return false;
-        }
-        //TODO: maybe we should do an api call here for modifying the amount on the API and then reading back the value.
-        m_gold -= amount;
-        OnGoldModified();
-        return true;
-    }*/
-
-    /*void OnGoldModified()
-    {
-        m_gold = Mathf.Clamp(m_gold, 0, int.MaxValue);
-
-        if (OnGoldModifiedEvent != null)
-        {
-            OnGoldModifiedEvent.Invoke();
-        }
-    }*/
-
-    /*public void AddGems(int amount)
-    {
-        //TODO: maybe we should do an api call here for modifying the amount on the API and then reading back the value.
-        m_gems += amount;
-        OnGemsModified();
-    }*/
-
-    /// <summary>
-    /// Tries to spend gems if it has enough.
-    /// Returns true if user had enough gems to spend, false otherwise.
-    /// </summary>
-    /// <param name="amount"></param>
-    /// <returns></returns>
-    /*public bool TrySpendGems(int amount)
-    {
-        //TODO: maybe we should do an api call here for modifying the amount on the API and then reading back the value.
-        if (m_gems < amount)
-        {
-            return false;
-        }
-        m_gems -= amount;
-        OnGemsModified();
-
-        return true;
-    }
-
-    void OnGemsModified()
-    {
-        m_gems = Mathf.Clamp(m_gems, 0, int.MaxValue);
-
-        if (OnGemsModifiedEvent != null)
-        {
-            OnGemsModifiedEvent.Invoke();
-        }
-    }*/
 }

--- a/Assets/Scripts/UI/GPUserProfileUI.cs
+++ b/Assets/Scripts/UI/GPUserProfileUI.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using TanksMP;
+using Photon.Pun;
 
 public class GPUserProfileUI : MonoBehaviour
 {
@@ -12,15 +13,12 @@ public class GPUserProfileUI : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        if (PlayerPrefs.HasKey(PrefsKeys.playerName))
-        {
-            m_inputField.text = PlayerPrefs.GetString(PrefsKeys.playerName);
-        }
+        m_inputField.text = APIManager.Instance.PlayerData.Name;
     }
 
     public void UpdateName()
     {
         PlayerPrefs.SetString(PrefsKeys.playerName, m_inputField.text);
     }
-    
+
 }

--- a/Assets/_Main/Scenes/Waiting_Room.unity
+++ b/Assets/_Main/Scenes/Waiting_Room.unity
@@ -14288,6 +14288,7 @@ MonoBehaviour:
   m_timersText:
   - {fileID: 397835791}
   - {fileID: 891353810}
+  m_weighAnchorButton: {fileID: 1659599171691007784}
   m_selectTeamText: Select Team
   m_searchingForPlayersText: Searching Players
   m_matchFoundText: Match Found


### PR DESCRIPTION
-Main menu username field now displays the steam name.
-Profile window username field now displays the steam name.
-Inputfield for modifying the username locked.
-Current energy amount text of the roulette screen now displays the energy that the player has.
-Weigh anchor button of the waiting room now grays out afer being clicked so its clear that the user doesn't need or should press it again.
-Added comments to GPProfileWindow class.
-Added comments to GPLevelUpScreen class.
-Added comments to GPWeeklyRewardScreen class.
-Added comments to GPFriendsTaps class.
-Cleaned and added comments to the GPPlayerProfile class.
-Moved the code for openning chests to a new class because that same logic needs to be used from many places (store, roulette, weekly rewards, level up rewards [maybe]).